### PR TITLE
Feature/cumulative functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Alea changelog
 
+## [0.2.3]
+### Added
+  - `Alea::CDF` module for Cumulative Distribution Function support.
+  - Supported distributions:
+    - Exponential
+    - Laplace
+    - Lognormal
+    - Normal
+    - Uniform
+
 ## [0.2.2]
 ### Added
-- **Uniform distribution** support.
-- New methods that take an upper limit or a range as optional arguments:
-  - `Alea::Random#uint : UInt64`
-  - `Alea::Random#float : Float64`
+  - **Uniform distribution** support.
+  - New methods that take an upper limit or a range as optional arguments:
+    - `Alea::Random#uint : UInt64`
+    - `Alea::Random#float : Float64`
 
 ## [0.2.1]
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 [![Build Status](https://travis-ci.org/nin93/alea.svg?branch=master)](https://travis-ci.org/nin93/alea)
 
-Alea is a library for generating pseudo-random samples from most known probability distributions,
+Alea is a collection of utilities to work with most known probability distributions,
 written in pure Crystal.
 
-Algorithms in this library are heavily derived from [NumPy](https://github.com/numpy/numpy) and [Julia](https://github.com/JuliaLang/julia) lang. Disclaimer in LICENSE file.
+This project is in early development state and many distributions are still missing, as well as cumulative distribution functions, so this library is not production-ready yet.
+
+Algorithms in this library are heavily derived from [NumPy](https://github.com/numpy/numpy) and [Julia lang](https://github.com/JuliaLang/julia). [LICENSE](https://github.com/nin93/alea/tree/master/LICENSE).
 
 ## Why Crystal?
 Crystal compiles to really fast native code without sacrificing any of the modern
 programming languages standards providing a nice and clean interface.
-
-**Cons**: poor library support, that's why this implementation aims be an enrichment to the community, so help is appreciated.
 
 ## Installation
 
@@ -25,20 +25,24 @@ programming languages standards providing a nice and clean interface.
 
 2. Run `shards install`
 
+## Usage
+
+```crystal
+require "alea"
+```
+
 ## PRNGs
 
 The algorithms in use for generating 64-bit uints and floats are from the **xoshiro** collection, designed by Sebastiano Vigna and David Blackman: really fast generators promising exquisite statistical properties as well.
 Read more about this PRNGs at: http://prng.di.unimi.it/
 
 By default the PRNG is `Alea::XSR128`, loaded with 128-bits of state and carrying a period of 2^128 - 1, but if more state is needed you can use `Alea::XSR256`, with corresponding state and period.
+
 **NOTE**: *~20% speed loss when using the extended version*. [Benchmarks](https://github.com/nin93/alea/tree/master/benchmarks).
 
-
-## Usage
+## Sampling
 
 ```crystal
-require "alea"
-
 random = Alea::Random.new
 random.normal # => -0.36790519967553736
 ```
@@ -49,23 +53,21 @@ random = Alea::Random.new(seed)
 random.exponential # => 2.8445710982736148
 ```
 
-You can also implement your own custom PRNG by inheriting `Alea::XSR` and passing it to the constructor by its class name.
-Here is an example using the 256-bit state PRNG `Alea:XSR256`:
+You can also implement your own custom PRNG by inheriting `Alea::XSR` and passing it to the constructor by its *class name*. Here is an example using the 256-bit state PRNG `Alea:XSR256`:
 ```crystal
 random = Alea::Random.new(Alea::XSR256)
 random.float # => 0.6533582874035311
 random.prng  # => Alea::XSR256
 
 # or seeded as well
-seed = 193u64
-random = Alea::Random.new(seed, Alea::XSR256)
+random = Alea::Random.new(193, Alea::XSR256)
 random.float # => 0.80750616724688
 ```
 
-## Unsafe methods
+### Unsafe methods
 
-Plain sampling methods (such `#normal`, `#gamma`) performs checks over arguments passed to avoid bad data generation or inner exceptions.
-In order to avoid them (checks are slow) you must use their unsafe version by prepending `next_` to them:
+Plain sampling methods (such as `#normal`, `#gamma`) performs checks over arguments passed to prevent bad data generation or inner exceptions.
+In order to avoid them (checks might be slow) you must use their unsafe version by prepending `next_` to them:
 
 ```crystal
 random = Alea::Random.new
@@ -73,13 +75,33 @@ random.normal(mean: 0, sigma: 0)      # raises ArgumentError: sigma is 0 or nega
 random.next_normal(mean: 0, sigma: 0) # this does not raise anything ever.
 ```
 
-## Development state
+Timings are definitely comparable, though. See the [benchmarks](https://github.com/nin93/alea/tree/master/benchmarks) for direct comparisons between those methods.
 
-Library is in development, current sampling methods are implemented for:
+### Supported Distributions
+
+Current sampling methods are implemented for the following distributions:
   - Beta
   - Chi Square
   - Exponential
   - Gamma
+  - Laplace
+  - Lognormal
+  - Normal
+  - Uniform
+
+## Cumulative Distribution Functions
+
+Use the `Alea::CDF` module to calculate the Cumulative Distribution Function of a real-valued *X* evaluated at *x*. Arguments passed to cdf methods to shape the distributions are analogous to those used for sampling:
+
+```crystal
+Alea::CDF.normal(0.0)                        # => 0.5
+Alea::CDF.normal(2.0, mean: 1.0, sigma: 0.5) # => 0.9772498680518208
+```
+
+### Supported Distributions
+
+Current cdf methods are implemented for the following distributions:
+  - Exponential
   - Laplace
   - Lognormal
   - Normal

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: alea
-version: 0.2.2
+version: 0.2.3
 
 authors:
   - Elia Franzella <eliafranzella@hotmail.it>

--- a/spec/random/beta_spec.cr
+++ b/spec/random/beta_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Beta" do
+  context "Beta" do
+    describe Alea::Random do
       describe "#beta" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/chi_square_spec.cr
+++ b/spec/random/chi_square_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "ChiSquare" do
+  context "ChiSquare" do
+    describe Alea::Random do
       describe "#chi_square" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/exponential_spec.cr
+++ b/spec/random/exponential_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Exponential" do
+  context "Exponential" do
+    describe Alea::Random do
       describe "#exponential" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/exponential_spec.cr
+++ b/spec/random/exponential_spec.cr
@@ -99,5 +99,45 @@ describe Alea do
         end
       end
     end
+
+    describe Alea::CDF do
+      describe "#exponential" do
+        it "raises ArgumentError if scale is 0" do
+          expect_raises ArgumentError do
+            Alea::CDF.exponential(0.0, scale: 0.0)
+          end
+        end
+
+        it "raises ArgumentError if scale is negative" do
+          expect_raises ArgumentError do
+            Alea::CDF.exponential(0.0, scale: -1.0)
+          end
+        end
+
+        it "returns the cdf of -1.0 in Exp(1.0)" do
+          Alea::CDF.exponential(-1.0).should eq(0.0)
+        end
+
+        it "returns the cdf of 0.0 in Exp(1.0)" do
+          Alea::CDF.exponential(0.0).should eq(0.0)
+        end
+
+        it "returns the cdf of 1.0 in Exp(1.0)" do
+          Alea::CDF.exponential(1.0).should eq(0.6321205588285577)
+        end
+
+        it "returns the cdf of 2.0 in Exp(1.0)" do
+          Alea::CDF.exponential(2.0).should eq(0.8646647167633873)
+        end
+
+        it "returns the cdf of 1.0 in Exp(0.5)" do
+          Alea::CDF.exponential(1.0, scale: 0.5).should eq(0.8646647167633873)
+        end
+
+        it "returns the cdf of 2.0 in Exp(0.5)" do
+          Alea::CDF.exponential(2.0, scale: 0.5).should eq(0.9816843611112658)
+        end
+      end
+    end
   end
 end

--- a/spec/random/gamma_spec.cr
+++ b/spec/random/gamma_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Gamma" do
+  context "Gamma" do
+    describe Alea::Random do
       describe "#gamma" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/laplace_spec.cr
+++ b/spec/random/laplace_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Laplace" do
+  context "Laplace" do
+    describe Alea::Random do
       describe "#laplace" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/laplace_spec.cr
+++ b/spec/random/laplace_spec.cr
@@ -132,5 +132,49 @@ describe Alea do
         end
       end
     end
+
+    describe Alea::CDF do
+      describe "#laplace" do
+        it "raises ArgumentError if scale is equal to 0.0" do
+          expect_raises ArgumentError do
+            Alea::CDF.laplace(0.0, scale: 0.0)
+          end
+        end
+
+        it "raises ArgumentError if scale is less than 0.0" do
+          expect_raises ArgumentError do
+            Alea::CDF.laplace(0.0, scale: -1.0)
+          end
+        end
+
+        it "returns the cdf of 0.0 in Laplace(0, 1)" do
+          Alea::CDF.laplace(0.0).should eq(0.5)
+        end
+
+        it "returns the cdf of 2.0 in Laplace(2, 1)" do
+          Alea::CDF.laplace(2.0, mean: 2.0).should eq(0.5)
+        end
+
+        it "returns the cdf of 2.0 in Laplace(0, 0.5)" do
+          Alea::CDF.laplace(2.0, scale: 0.5).should eq(0.9908421805556329)
+        end
+
+        it "returns the cdf of 2.0 in Laplace(1, 0.5)" do
+          Alea::CDF.laplace(2.0, mean: 1.0, scale: 0.5).should eq(0.9323323583816936)
+        end
+
+        it "returns the cdf of -2.0 in Laplace(-2, 1)" do
+          Alea::CDF.laplace(-2.0, mean: -2.0).should eq(0.5)
+        end
+
+        it "returns the cdf of -2.0 in Laplace(0, 0.5)" do
+          Alea::CDF.laplace(-2.0, scale: 0.5).should eq(0.00915781944436709)
+        end
+
+        it "returns the cdf of -2.0 in Laplace(1, 0.5)" do
+          Alea::CDF.laplace(-2.0, mean: 1.0, scale: 0.5).should eq(0.0012393760883331792)
+        end
+      end
+    end
   end
 end

--- a/spec/random/lognormal_spec.cr
+++ b/spec/random/lognormal_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Lognormal" do
+  context "Lognormal" do
+    describe Alea::Random do
       describe "#lognormal" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/lognormal_spec.cr
+++ b/spec/random/lognormal_spec.cr
@@ -155,5 +155,45 @@ describe Alea do
         end
       end
     end
+
+    describe Alea::CDF do
+      describe "#lognormal" do
+        it "raises ArgumentError if stdev is equal to 0.0" do
+          expect_raises ArgumentError do
+            Alea::CDF.lognormal(0.0, sigma: 0.0)
+          end
+        end
+
+        it "raises ArgumentError if stdev is less than 0.0" do
+          expect_raises ArgumentError do
+            Alea::CDF.lognormal(0.0, sigma: -1.0)
+          end
+        end
+
+        it "returns the cdf of 0.0 in LogN(0, 1)" do
+          Alea::CDF.lognormal(0.0).should eq(0.0)
+        end
+
+        it "returns the cdf of 1.0 in LogN(0, 1)" do
+          Alea::CDF.lognormal(1.0).should eq(0.5)
+        end
+
+        it "returns the cdf of -1.0 in LogN(0, 1)" do
+          Alea::CDF.lognormal(-1.0).should eq(0.0)
+        end
+
+        it "returns the cdf of 2.0 in LogN(2, 1)" do
+          Alea::CDF.lognormal(2.0, mean: 2.0).should eq(0.09563135117897992)
+        end
+
+        it "returns the cdf of 2.0 in LogN(0, 0.5)" do
+          Alea::CDF.lognormal(2.0, sigma: 0.5).should eq(0.9171714809983015)
+        end
+
+        it "returns the cdf of 2.0 in LogN(1, 0.5)" do
+          Alea::CDF.lognormal(2.0, mean: 1.0, sigma: 0.5).should eq(0.26970493073490953)
+        end
+      end
+    end
   end
 end

--- a/spec/random/normal_spec.cr
+++ b/spec/random/normal_spec.cr
@@ -143,5 +143,49 @@ describe Alea do
         end
       end
     end
+
+    describe Alea::CDF do
+      describe "#normal" do
+        it "raises ArgumentError if stdev is equal to 0.0" do
+          expect_raises ArgumentError do
+            Alea::CDF.normal(0.0, sigma: 0.0)
+          end
+        end
+
+        it "raises ArgumentError if stdev is less than 0.0" do
+          expect_raises ArgumentError do
+            Alea::CDF.normal(0.0, sigma: -1.0)
+          end
+        end
+
+        it "returns the cdf of 0.0 in N(0, 1)" do
+          Alea::CDF.normal(0.0).should eq(0.5)
+        end
+
+        it "returns the cdf of 2.0 in N(2, 1)" do
+          Alea::CDF.normal(2.0, mean: 2.0).should eq(0.5)
+        end
+
+        it "returns the cdf of 2.0 in N(0, 0.5)" do
+          Alea::CDF.normal(2.0, sigma: 0.5).should eq(0.9999683287581669)
+        end
+
+        it "returns the cdf of 2.0 in N(1, 0.5)" do
+          Alea::CDF.normal(2.0, mean: 1.0, sigma: 0.5).should eq(0.9772498680518208)
+        end
+
+        it "returns the cdf of -2.0 in N(-2, 1)" do
+          Alea::CDF.normal(-2.0, mean: -2.0).should eq(0.5)
+        end
+
+        it "returns the cdf of -2.0 in N(0, 0.5)" do
+          Alea::CDF.normal(-2.0, sigma: 0.5).should eq(3.167124183311998e-5)
+        end
+
+        it "returns the cdf of -2.0 in N(1, 0.5)" do
+          Alea::CDF.normal(-2.0, mean: 1.0, sigma: 0.5).should eq(9.865876449133282e-10)
+        end
+      end
+    end
   end
 end

--- a/spec/random/normal_spec.cr
+++ b/spec/random/normal_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Normal" do
+  context "Normal" do
+    describe Alea::Random do
       describe "#normal" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/uniform_spec.cr
+++ b/spec/random/uniform_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Alea do
-  describe Alea::Random do
-    context "Uniform" do
+  context "Uniform" do
+    describe Alea::Random do
       describe "#uint" do
         it "accepts any sized Int as argument(s)" do
           {% for bits in %i[8 16 32 64 128] %}

--- a/spec/random/uniform_spec.cr
+++ b/spec/random/uniform_spec.cr
@@ -244,5 +244,41 @@ describe Alea do
         end
       end
     end
+
+    describe Alea::CDF do
+      describe "#uniform" do
+        it "raises ArgumentError if min is equal to max" do
+          expect_raises ArgumentError do
+            Alea::CDF.uniform(0.0, min: 0.0, max: 0.0)
+          end
+        end
+
+        it "raises ArgumentError if range is badly ordered" do
+          expect_raises ArgumentError do
+            Alea::CDF.uniform(0.0, min: 0.0, max: -1.0)
+          end
+        end
+
+        it "returns the cdf of -1.0 in U(0, 100)" do
+          Alea::CDF.uniform(-1.0, min: 0.0, max: 100.0).should eq(0.0)
+        end
+
+        it "returns the cdf of 0.0 in U(0, 100)" do
+          Alea::CDF.uniform(0.0, min: 0.0, max: 100.0).should eq(0.0)
+        end
+
+        it "returns the cdf of 2.0 in U(0, 100)" do
+          Alea::CDF.uniform(50.0, min: 0.0, max: 100.0).should eq(0.5)
+        end
+
+        it "returns the cdf of 100.0 in U(0, 100)" do
+          Alea::CDF.uniform(100.0, min: 0.0, max: 100.0).should eq(1.0)
+        end
+
+        it "returns the cdf of 101.0 in U(0, 100)" do
+          Alea::CDF.uniform(101.0, min: 0.0, max: 100.0).should eq(1.0)
+        end
+      end
+    end
   end
 end

--- a/src/alea/cdf.cr
+++ b/src/alea/cdf.cr
@@ -1,0 +1,8 @@
+module Alea
+  # The CDF module implements the *Cumulative Distribution Functions* for the supported distributions.
+  # The cdf of a real valued random variable X evaluated at x is the probability that X will take a value
+  # less or equal to x. It is the inverse of the *Percent Point Function* (PPF), the one used by most of
+  # the implementations inside this library to perform sampling.
+  module CDF
+  end
+end

--- a/src/alea/cdf.cr
+++ b/src/alea/cdf.cr
@@ -4,5 +4,6 @@ module Alea
   # less or equal to x. It is the inverse of the *Percent Point Function* (PPF), the one used by most of
   # the implementations inside this library to perform sampling.
   module CDF
+    extend self
   end
 end

--- a/src/alea/distributions/exponential.cr
+++ b/src/alea/distributions/exponential.cr
@@ -40,4 +40,16 @@ module Alea
       end
     {% end %}
   end
+
+  module CDF
+    # Returns the probability of X being less or equal to x
+    # with given scale of the distribution. Scale parameter is lambda^-1.
+    def exponential(x : Float, scale : Float = 1.0) : Float64
+      unless scale > 0.0
+        raise ArgumentError.new "Expected scale to be positive."
+      end
+      x <= 0.0 && return 0.0
+      1.0 - Math.exp(-x / scale)
+    end
+  end
 end

--- a/src/alea/distributions/laplace.cr
+++ b/src/alea/distributions/laplace.cr
@@ -53,4 +53,17 @@ module Alea
       {% end %}
     {% end %}
   end
+
+  module CDF
+    # Returns the probability of X being less or equal to x
+    # with given mean and scale of the distribution.
+    def laplace(x : Float, mean : Float = 0.0, scale : Float = 1.0) : Float64
+      unless scale > 0.0
+        raise ArgumentError.new "Expected scale to be positive."
+      end
+      a = (x - mean) / scale
+      x < mean && return 0.5 * Math.exp(a)
+      1.0 - 0.5 * Math.exp(-a)
+    end
+  end
 end

--- a/src/alea/distributions/lognormal.cr
+++ b/src/alea/distributions/lognormal.cr
@@ -42,4 +42,16 @@ module Alea
       {% end %}
     {% end %}
   end
+
+  module CDF
+    # Returns the probability of X being less or equal to x
+    # with given mean and standard deviation of the underlying normal distribution.
+    def lognormal(x : Float, mean : Float = 0.0, sigma : Float = 1.0) : Float64
+      unless sigma > 0.0
+        raise ArgumentError.new "Expected sigma to be positive."
+      end
+      x <= 0.0 && return 0.0
+      0.5 + 0.5 * (Math.erf((Math.log(x) - mean) / (sigma * 1.4142135623730951)))
+    end
+  end
 end

--- a/src/alea/distributions/normal.cr
+++ b/src/alea/distributions/normal.cr
@@ -60,4 +60,15 @@ module Alea
       {% end %}
     {% end %}
   end
+
+  module CDF
+    # Returns the probability of X being less or equal to x
+    # with given mean and standard deviation of the distribution.
+    def normal(x : Float, mean : Float = 0.0, sigma : Float = 1.0) : Float64
+      unless sigma > 0.0
+        raise ArgumentError.new "Expected sigma to be positive."
+      end
+      0.5 * (1.0 + Math.erf((x - mean) / (sigma * 1.4142135623730951)))
+    end
+  end
 end

--- a/src/alea/distributions/uniform.cr
+++ b/src/alea/distributions/uniform.cr
@@ -66,4 +66,17 @@ module Alea
       @prng.next_f * span + range.begin
     end
   end
+
+  module CDF
+    # Returns the probability of X being less or equal to x
+    # with given scale of the distribution.
+    def uniform(x : Float, min : Float, max : Float) : Float64
+      unless min < max
+        raise ArgumentError.new "Invalid range for uniform: #{min}...#{max}"
+      end
+      x <= min && return 0.0
+      x >= max && return 1.0
+      (x - min) / (max - min)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the Cumulative Distribution Functions support for the following distributions:
  - Exponential
  - Laplace
  - Lognormal
  - Normal
  - Uniform

A new module, `Alea::CDF`, is provided to calculate the cdf of a real-valued *X* evaluated at *x*:

```crystal
Alea::CDF.normal(0.0) # => 0.5
```
Arguments passed to shape the focused distribution are analogous to those used for sampling:
```crystal
Alea::CDF.normal(x: 2.0, mean: 1.0, sigma: 0.5) # => 0.9772498680518208
```