### PR TITLE
ENH: Exceptions

### DIFF
--- a/spec/distributions/beta_spec.cr
+++ b/spec/distributions/beta_spec.cr
@@ -21,26 +21,50 @@ describe Alea do
           SpecRng.beta a: 1.0_f64, b: 1.0_f64
         end
 
-        it "raises ArgumentError if a is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if a is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.beta a: 0.0 / 0.0, b: 1.0
+          end
+        end
+
+        it "raises Alea::InfinityError if a is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.beta a: 1.0 / 0.0, b: 1.0
+          end
+        end
+
+        it "raises Alea::NaNError if b is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.beta a: 1.0, b: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if b is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.beta a: 1.0, b: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if a is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.beta a: 0.0, b: 1.0
           end
         end
 
-        it "raises ArgumentError if a is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if a is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.beta a: -1.0, b: 1.0
           end
         end
 
-        it "raises ArgumentError if b is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if b is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.beta a: 1.0, b: 0.0
           end
         end
 
-        it "raises ArgumentError if b is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if b is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.beta a: 1.0, b: -1.0
           end
         end

--- a/spec/distributions/chi_square_spec.cr
+++ b/spec/distributions/chi_square_spec.cr
@@ -21,14 +21,26 @@ describe Alea do
           SpecRng.chi_square 1.0_f64
         end
 
-        it "raises ArgumentError if degrees of freedom are 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if degrees of freedom are NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.chi_square freedom: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if degrees of freedom are Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.chi_square freedom: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if degrees of freedom are 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.chi_square freedom: 0.0
           end
         end
 
-        it "raises ArgumentError if degrees of freedom are negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if degrees of freedom are negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.chi_square freedom: -1.0
           end
         end
@@ -79,14 +91,14 @@ describe Alea do
 
     describe Alea::CDF do
       describe "#chi_square" do
-        it "raises ArgumentError if freedom is equal to 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if freedom is equal to 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.chi_square(0.0, freedom: 0.0)
           end
         end
 
-        it "raises ArgumentError if freedom is less than 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if freedom is less than 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.chi_square(0.0, freedom: -1.0)
           end
         end

--- a/spec/distributions/exponential_spec.cr
+++ b/spec/distributions/exponential_spec.cr
@@ -21,14 +21,26 @@ describe Alea do
           SpecRng.exponential 1.0_f64
         end
 
-        it "raises ArgumentError if scale is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if a is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.exponential scale: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if a is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.exponential scale: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if scale is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.exponential scale: 0.0
           end
         end
 
-        it "raises ArgumentError if scale is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if scale is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.exponential scale: -1.0
           end
         end
@@ -102,14 +114,38 @@ describe Alea do
 
     describe Alea::CDF do
       describe "#exponential" do
-        it "raises ArgumentError if scale is 0" do
-          expect_raises ArgumentError do
+        it "raises Alea::NaNError if x is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.exponential(0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if x is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.exponential(1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if scale is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.exponential(1.0, scale: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if scale is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.exponential(1.0, scale: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::UndefinedError if scale is 0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.exponential(0.0, scale: 0.0)
           end
         end
 
-        it "raises ArgumentError if scale is negative" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if scale is negative" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.exponential(0.0, scale: -1.0)
           end
         end

--- a/spec/distributions/gamma_spec.cr
+++ b/spec/distributions/gamma_spec.cr
@@ -26,26 +26,50 @@ describe Alea do
           SpecRng.gamma 1.0_f64, 1.0_f64
         end
 
-        it "raises ArgumentError if shape is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if shape is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.gamma shape: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if shape is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.gamma shape: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::NaNError if scale NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.gamma 1.0, scale: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if scale Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.gamma 1.0, scale: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if shape is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.gamma shape: 0.0
           end
         end
 
-        it "raises ArgumentError if shape is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if shape is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.gamma shape: -1.0
           end
         end
 
-        it "raises ArgumentError if scale is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if scale is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.gamma 1.0, scale: 0.0
           end
         end
 
-        it "raises ArgumentError if scale is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if scale is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.gamma 1.0, scale: -1.0
           end
         end

--- a/spec/distributions/laplace_spec.cr
+++ b/spec/distributions/laplace_spec.cr
@@ -26,14 +26,38 @@ describe Alea do
           SpecRng.laplace 1.0_f64, 1.0_f64
         end
 
-        it "raises ArgumentError if scale is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if mean is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.laplace mean: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if mean is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.laplace mean: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::NaNError if scale NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.laplace 1.0, scale: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if scale Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.laplace 1.0, scale: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if scale is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.laplace 1.0, scale: 0.0
           end
         end
 
-        it "raises ArgumentError if scale is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if scale is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.laplace 1.0, scale: -1.0
           end
         end
@@ -135,14 +159,50 @@ describe Alea do
 
     describe Alea::CDF do
       describe "#laplace" do
-        it "raises ArgumentError if scale is equal to 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::NaNError if x is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.laplace(0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if x is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.laplace(1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if mean is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.laplace(1.0, mean: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if mean is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.laplace(1.0, mean: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if scale is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.laplace(1.0, scale: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if scale is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.laplace(1.0, scale: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::UndefinedError if scale is equal to 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.laplace(0.0, scale: 0.0)
           end
         end
 
-        it "raises ArgumentError if scale is less than 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if scale is less than 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.laplace(0.0, scale: -1.0)
           end
         end

--- a/spec/distributions/lognormal_spec.cr
+++ b/spec/distributions/lognormal_spec.cr
@@ -26,14 +26,38 @@ describe Alea do
           SpecRng.lognormal 1.0_f64, 1.0_f64
         end
 
-        it "raises ArgumentError if sigma is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if mean is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.lognormal mean: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if mean is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.lognormal mean: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::NaNError if sigma NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.lognormal 1.0, sigma: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if sigma Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.lognormal 1.0, sigma: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if sigma is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.lognormal sigma: 0.0
           end
         end
 
-        it "raises ArgumentError if sigma is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if sigma is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.lognormal sigma: -1.0
           end
         end
@@ -158,14 +182,50 @@ describe Alea do
 
     describe Alea::CDF do
       describe "#lognormal" do
-        it "raises ArgumentError if stdev is equal to 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::NaNError if x is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.lognormal(0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if x is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.lognormal(1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if mean is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.lognormal(0.0, mean: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if mean is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.lognormal(0.0, mean: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if stdev is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.lognormal(0.0, sigma: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if stdev is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.lognormal(0.0, sigma: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::UndefinedError if stdev is equal to 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.lognormal(0.0, sigma: 0.0)
           end
         end
 
-        it "raises ArgumentError if stdev is less than 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if stdev is less than 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.lognormal(0.0, sigma: -1.0)
           end
         end

--- a/spec/distributions/normal_spec.cr
+++ b/spec/distributions/normal_spec.cr
@@ -26,14 +26,38 @@ describe Alea do
           SpecRng.normal 1.0_f64, 1.0_f64
         end
 
-        it "raises ArgumentError if sigma is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if mean is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.normal mean: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if mean is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.normal mean: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::NaNError if sigma NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.normal 1.0, sigma: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if sigma Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.normal 1.0, sigma: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if sigma is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.normal sigma: 0.0
           end
         end
 
-        it "raises ArgumentError if sigma is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if sigma is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.normal sigma: -1.0
           end
         end
@@ -146,14 +170,50 @@ describe Alea do
 
     describe Alea::CDF do
       describe "#normal" do
-        it "raises ArgumentError if stdev is equal to 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::NaNError if x is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.normal(0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if x is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.normal(1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if mean is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.normal(0.0, mean: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if mean is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.normal(0.0, mean: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if stdev is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.normal(0.0, sigma: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if stdev is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.normal(0.0, sigma: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::UndefinedError if stdev is equal to 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.normal(0.0, sigma: 0.0)
           end
         end
 
-        it "raises ArgumentError if stdev is less than 0.0" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if stdev is less than 0.0" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.normal(0.0, sigma: -1.0)
           end
         end

--- a/spec/distributions/poisson_spec.cr
+++ b/spec/distributions/poisson_spec.cr
@@ -15,14 +15,20 @@ describe Alea do
           SpecRng.poisson 1.0_f64
         end
 
-        it "raises ArgumentError if lambda is 0.0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::InfinityError if lambda is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.poisson lam: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if lambda is 0.0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.poisson lam: 0.0
           end
         end
 
-        it "raises ArgumentError if lambda is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if lambda is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.poisson lam: -1.0
           end
         end
@@ -38,6 +44,10 @@ describe Alea do
         it "accepts any sized Float as argument(s)" do
           SpecRng.next_poisson 1.0_f32
           SpecRng.next_poisson 1.0_f64
+        end
+
+        it "returns 0.0 if lambda is 0.0" do
+          SpecRng.next_poisson(lam: 0.0).should eq(0.0)
         end
 
         it "generates poisson-distributed random values with lambda 1.0" do

--- a/spec/distributions/uniform_spec.cr
+++ b/spec/distributions/uniform_spec.cr
@@ -18,32 +18,32 @@ describe Alea do
           {% end %}
         end
 
-        it "raises ArgumentError if max is 0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if max is 0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.uint max: 0
           end
         end
 
-        it "raises ArgumentError if max is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if max is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.uint max: -1
           end
         end
 
-        it "raises ArgumentError if range is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if range is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.uint (-1..0)
           end
         end
 
-        it "raises ArgumentError if range is badly ordered" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if range is badly ordered" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.uint (1..0)
           end
         end
 
-        it "raises ArgumentError if range is badly choosen" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if range is badly choosen" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.uint (1...1)
           end
         end
@@ -138,26 +138,62 @@ describe Alea do
           {% end %}
         end
 
-        it "raises ArgumentError if max is 0" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if max is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.float max: 0.0 / 0.0
+          end
+        end
+
+        it "raises Alea::InfinityError if max is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.float max: 1.0 / 0.0
+          end
+        end
+
+        it "raises Alea::UndefinedError if max is 0" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.float max: 0.0
           end
         end
 
-        it "raises ArgumentError if max is negative" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if max is negative" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.float max: -1.0
           end
         end
 
-        it "raises ArgumentError if range is badly ordered" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::NaNError if left bound is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.float ((0.0 / 0.0)..0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if left bound is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.float ((1.0 / 0.0)..0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if right bound is NaN" do
+          expect_raises(Alea::NaNError) do
+            SpecRng.float (0.0..(0.0 / 0.0))
+          end
+        end
+
+        it "raises Alea::InfinityError if right bound is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            SpecRng.float (0.0..(1.0 / 0.0))
+          end
+        end
+
+        it "raises Alea::UndefinedError if range is badly ordered" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.float (1.0..0.0)
           end
         end
 
-        it "raises ArgumentError if range is badly choosen" do
-          expect_raises(ArgumentError) do
+        it "raises Alea::UndefinedError if range is badly choosen" do
+          expect_raises(Alea::UndefinedError) do
             SpecRng.float (1.0...1.0)
           end
         end
@@ -247,14 +283,50 @@ describe Alea do
 
     describe Alea::CDF do
       describe "#uniform" do
-        it "raises ArgumentError if min is equal to max" do
-          expect_raises ArgumentError do
+        it "raises Alea::NaNError if x is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.uniform(0.0 / 0.0, min: 0.0, max: 1.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if x is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.uniform(1.0 / 0.0, min: 0.0, max: 1.0)
+          end
+        end
+
+        it "raises Alea::NaNError if min is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.uniform(0.0, min: 0.0 / 0.0, max: 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if min is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.uniform(0.0, min: 1.0 / 0.0, max: 0.0)
+          end
+        end
+
+        it "raises Alea::NaNError if max is NaN" do
+          expect_raises(Alea::NaNError) do
+            Alea::CDF.uniform(0.0, min: 0.0, max: 0.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::InfinityError if max is Infinity" do
+          expect_raises(Alea::InfinityError) do
+            Alea::CDF.uniform(0.0, min: 0.0, max: 1.0 / 0.0)
+          end
+        end
+
+        it "raises Alea::UndefinedError if min is equal to max" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.uniform(0.0, min: 0.0, max: 0.0)
           end
         end
 
-        it "raises ArgumentError if range is badly ordered" do
-          expect_raises ArgumentError do
+        it "raises Alea::UndefinedError if range is badly ordered" do
+          expect_raises Alea::UndefinedError do
             Alea::CDF.uniform(0.0, min: 0.0, max: -1.0)
           end
         end

--- a/src/alea/internal/ierr.cr
+++ b/src/alea/internal/ierr.cr
@@ -1,0 +1,28 @@
+module Alea
+  class UndefinedError < Exception; end
+
+  class NaNError < Exception; end
+
+  class InfinityError < Exception; end
+
+  class NoConvergeError < Exception; end
+
+  macro sanity_check(x, param, caller)
+    if !({{x.id}} == {{x.id}})
+      # NaN encountered
+      raise Alea::NaNError.new \
+        "Invalid value for `{{caller.id}}': {{param.id}} = #{{{x.id}}}"
+    elsif {{x.id}} != 0.0 && {{x.id}} * 2.0 == {{x.id}}
+      # Infinity encountered
+      raise Alea::InfinityError.new \
+        "Invalid value for `{{caller.id}}': {{param.id}} = #{{{x.id}}}"
+    end
+  end
+
+  macro param_check(x, comp, y, param, caller)
+    if {{x.id}} {{comp.id}} {{y.id}}
+      raise Alea::UndefinedError.new \
+        "Invalid value for `{{caller.id}}': {{param.id}} = #{{{x.id}}} {{comp.id}} #{{{y.id}}}"
+    end
+  end
+end

--- a/src/alea/prob/pchisq.cr
+++ b/src/alea/prob/pchisq.cr
@@ -2,9 +2,9 @@ module Alea::CDF
   # Returns the probability of X being less or equal to x
   # with given degrees of freedom of the distribution.
   def self.chi_square(x : Float, freedom : Float = 1.0) : Float64
-    unless freedom > 0.0
-      raise ArgumentError.new "Expected degrees of freedom to be positive"
-    end
+    Alea.sanity_check(x, :x, :chi_square)
+    Alea.sanity_check(freedom, :freedom, :chi_square)
+    Alea.param_check(freedom, :<=, 0.0, :freedom, :chi_square)
     x <= 0.0 && return 0.0
     Alea::Internal.incg_regular_lower(freedom * 0.5, x * 0.5)
   end

--- a/src/alea/prob/pexp.cr
+++ b/src/alea/prob/pexp.cr
@@ -2,9 +2,9 @@ module Alea::CDF
   # Returns the probability of X being less or equal to x
   # with given scale of the distribution. Scale parameter is lambda^-1.
   def self.exponential(x : Float, scale : Float = 1.0) : Float64
-    unless scale > 0.0
-      raise ArgumentError.new "Expected scale to be positive."
-    end
+    Alea.sanity_check(x, :x, :exponential)
+    Alea.sanity_check(scale, :scale, :exponential)
+    Alea.param_check(scale, :<=, 0.0, :scale, :exponential)
     x <= 0.0 && return 0.0
     1.0 - Math.exp(-x / scale)
   end

--- a/src/alea/prob/plaplace.cr
+++ b/src/alea/prob/plaplace.cr
@@ -2,9 +2,10 @@ module Alea::CDF
   # Returns the probability of X being less or equal to x
   # with given mean and scale of the distribution.
   def self.laplace(x : Float, mean : Float = 0.0, scale : Float = 1.0) : Float64
-    unless scale > 0.0
-      raise ArgumentError.new "Expected scale to be positive."
-    end
+    Alea.sanity_check(x, :x, :laplace)
+    Alea.sanity_check(mean, :mean, :laplace)
+    Alea.sanity_check(scale, :scale, :laplace)
+    Alea.param_check(scale, :<=, 0.0, :scale, :laplace)
     a = (x - mean) / scale
     x < mean && return 0.5 * Math.exp(a)
     1.0 - 0.5 * Math.exp(-a)

--- a/src/alea/prob/plognor.cr
+++ b/src/alea/prob/plognor.cr
@@ -2,9 +2,10 @@ module Alea::CDF
   # Returns the probability of X being less or equal to x
   # with given mean and standard deviation of the underlying normal distribution.
   def self.lognormal(x : Float, mean : Float = 0.0, sigma : Float = 1.0) : Float64
-    unless sigma > 0.0
-      raise ArgumentError.new "Expected sigma to be positive."
-    end
+    Alea.sanity_check(x, :x, :lognormal)
+    Alea.sanity_check(mean, :mean, :lognormal)
+    Alea.sanity_check(sigma, :sigma, :lognormal)
+    Alea.param_check(sigma, :<=, 0.0, :sigma, :lognormal)
     x <= 0.0 && return 0.0
     0.5 + 0.5 * (Math.erf((Math.log(x) - mean) / (sigma * 1.4142135623730951)))
   end

--- a/src/alea/prob/pnorm.cr
+++ b/src/alea/prob/pnorm.cr
@@ -2,9 +2,10 @@ module Alea::CDF
   # Returns the probability of X being less or equal to x
   # with given mean and standard deviation of the distribution.
   def self.normal(x : Float, mean : Float = 0.0, sigma : Float = 1.0) : Float64
-    unless sigma > 0.0
-      raise ArgumentError.new "Expected sigma to be positive."
-    end
+    Alea.sanity_check(x, :x, :normal)
+    Alea.sanity_check(mean, :mean, :normal)
+    Alea.sanity_check(sigma, :sigma, :normal)
+    Alea.param_check(sigma, :<=, 0.0, :sigma, :normal)
     0.5 * (1.0 + Math.erf((x - mean) / (sigma * 1.4142135623730951)))
   end
 end

--- a/src/alea/prob/punif.cr
+++ b/src/alea/prob/punif.cr
@@ -2,8 +2,11 @@ module Alea::CDF
   # Returns the probability of X being less or equal to x
   # with given scale of the distribution.
   def self.uniform(x : Float, min : Float, max : Float) : Float64
+    Alea.sanity_check(x, :x, :uniform)
+    Alea.sanity_check(min, :min, :uniform)
+    Alea.sanity_check(max, :max, :uniform)
     unless min < max
-      raise ArgumentError.new "Invalid range for uniform: #{min}...#{max}"
+      raise Alea::UndefinedError.new "Invalid value for `uniform': range = #{min}...#{max}"
     end
     x <= min && return 0.0
     x >= max && return 1.0

--- a/src/alea/rand/rbeta.cr
+++ b/src/alea/rand/rbeta.cr
@@ -6,10 +6,10 @@ module Alea
     # Named arguments are mandatory to prevent ambiguity.
     # Raises ArgumentError if parameters are negative or zero.
     def beta(*, a, b)
-      if a <= 0.0 || b <= 0.0
-        raise ArgumentError.new "Expected shape parameters to be greater than 0.0."
-      end
-
+      Alea.sanity_check(a, :a, :beta)
+      Alea.sanity_check(b, :b, :beta)
+      Alea.param_check(a, :<=, 0.0, :a, :beta)
+      Alea.param_check(b, :<=, 0.0, :b, :beta)
       next_beta a: a, b: b
     end
 

--- a/src/alea/rand/rchisq.cr
+++ b/src/alea/rand/rchisq.cr
@@ -5,10 +5,8 @@ module Alea
     # Generate a chi^2-distributed random `Float64` with given degrees of freedom.
     # Raises ArgumentError if parameter is negative or zero.
     def chi_square(freedom)
-      if freedom <= 0.0
-        raise ArgumentError.new "Expected freedom parameter to be greater than 0.0."
-      end
-
+      Alea.sanity_check(freedom, :freedom, :chi_square)
+      Alea.param_check(freedom, :<=, 0.0, :freedom, :chi_square)
       next_chi_square freedom
     end
 

--- a/src/alea/rand/rexp.cr
+++ b/src/alea/rand/rexp.cr
@@ -1,4 +1,5 @@
 require "../internal/izigg"
+require "../internal/ierr"
 
 module Alea
   struct Random
@@ -6,10 +7,8 @@ module Alea
     # Scale parameter is lambda^-1.
     # Raises ArgumentError if parameter is negative or zero.
     def exponential(scale = 1.0)
-      if scale <= 0.0
-        raise ArgumentError.new "Expected scale parameter to be greater than 0.0."
-      end
-
+      Alea.sanity_check(scale, :scale, :exponential)
+      Alea.param_check(scale, :<=, 0.0, :scale, :exponential)
       next_exponential scale
     end
 

--- a/src/alea/rand/rgamma.cr
+++ b/src/alea/rand/rgamma.cr
@@ -1,3 +1,4 @@
+require "../internal/ierr"
 require "./rnorm"
 require "./rexp"
 
@@ -7,10 +8,10 @@ module Alea
     # with given shape and scale.
     # Raises ArgumentError if parameters are negative or zero.
     def gamma(shape, scale = 1.0)
-      if shape <= 0.0 || scale <= 0.0
-        raise ArgumentError.new "Expected shape and scale parameters to be greater than 0.0."
-      end
-
+      Alea.sanity_check(shape, :shape, :gamma)
+      Alea.sanity_check(scale, :scale, :gamma)
+      Alea.param_check(shape, :<=, 0.0, :shape, :gamma)
+      Alea.param_check(scale, :<=, 0.0, :scale, :gamma)
       next_gamma shape, scale
     end
 

--- a/src/alea/rand/rlaplace.cr
+++ b/src/alea/rand/rlaplace.cr
@@ -1,13 +1,14 @@
+require "../internal/ierr"
+
 module Alea
   struct Random
     # Generate a laplace-distributed random `Float64`
     # with given center and scale.
     # Raises ArgumentError if scale parameter is negative or zero.
     def laplace(mean = 0.0, scale = 1.0)
-      if scale <= 0.0
-        raise ArgumentError.new "Expected scale parameter to be greater than 0.0."
-      end
-
+      Alea.sanity_check(mean, :mean, :laplace)
+      Alea.sanity_check(scale, :scale, :laplace)
+      Alea.param_check(scale, :<=, 0.0, :scale, :laplace)
       next_laplace mean, scale
     end
 

--- a/src/alea/rand/rlognor.cr
+++ b/src/alea/rand/rlognor.cr
@@ -1,3 +1,4 @@
+require "../internal/ierr"
 require "./rnorm"
 
 module Alea
@@ -6,10 +7,9 @@ module Alea
     # mean and standard deviation of the underlying normal distribution.
     # Raises ArgumentError if sigma parameter is negative or zero.
     def lognormal(mean = 0.0, sigma = 1.0)
-      if sigma <= 0.0
-        raise ArgumentError.new "Expected standard deviation to be greater than 0.0."
-      end
-
+      Alea.sanity_check(mean, :mean, :lognormal)
+      Alea.sanity_check(sigma, :sigma, :lognormal)
+      Alea.param_check(sigma, :<=, 0.0, :sigma, :lognormal)
       next_lognormal mean, sigma
     end
 

--- a/src/alea/rand/rnorm.cr
+++ b/src/alea/rand/rnorm.cr
@@ -1,4 +1,5 @@
 require "../internal/izigg"
+require "../internal/ierr"
 
 module Alea
   struct Random
@@ -6,10 +7,9 @@ module Alea
     # with given mean and standard deviation.
     # Raises ArgumentError if sigma parameter is negative or zero.
     def normal(mean = 0.0, sigma = 1.0)
-      if sigma <= 0.0
-        raise ArgumentError.new "Expected standard deviation to be greater than 0.0."
-      end
-
+      Alea.sanity_check(mean, :mean, :normal)
+      Alea.sanity_check(sigma, :sigma, :normal)
+      Alea.param_check(sigma, :<=, 0.0, :sigma, :normal)
       next_normal mean, sigma
     end
 

--- a/src/alea/rand/rpoiss.cr
+++ b/src/alea/rand/rpoiss.cr
@@ -5,10 +5,8 @@ module Alea
     # Generate a poisson-distributed random `Int64` with given lambda parameter.
     # Raises ArgumentError if lambda parameter is negative or zero.
     def poisson(lam = 1.0)
-      unless lam > 0.0
-        raise ArgumentError.new "Expected lambda to be greater than 0.0"
-      end
-
+      Alea.sanity_check(lam, :lam, :poisson)
+      Alea.param_check(lam, :<=, 0.0, :lam, :poisson)
       next_poisson lam
     end
 

--- a/src/alea/rand/runif.cr
+++ b/src/alea/rand/runif.cr
@@ -8,9 +8,8 @@ module Alea
     # Generate a uniform-distributed `UInt64` in [0, max).
     # Raises ArgumentError if parameter is negative or zero.
     def uint(max : Int) : UInt64
-      unless max > 0
-        raise ArgumentError.new "Invalid limit for uint: #{max}"
-      end
+      # No sanity check here: max is an Int
+      Alea.param_check(max, :<=, 0, :max, :uint)
       max == UInt64::MAX && return @prng.next_u
       lim = UInt64::MAX - (UInt64::MAX % max)
       while true
@@ -23,12 +22,12 @@ module Alea
     # Raises ArgumentError if range parameter is not a subset of N+.
     def uint(range : Range(Int, Int)) : UInt64
       unless 0 <= range.begin <= range.end
-        raise ArgumentError.new "Invalid range for uint: #{range}"
+        raise Alea::UndefinedError.new "Invalid value for `uint': range = #{range}"
       end
       span = range.end - range.begin
       if range.excludes_end?
         if range.end == range.begin
-          raise ArgumentError.new "Invalid range for uint: #{range}"
+          raise Alea::UndefinedError.new "Invalid value for `uint': range = #{range}"
         end
       else
         span += 1
@@ -44,21 +43,22 @@ module Alea
     # Generate a uniform-distributed `Float64` in [0.0, max).
     # Raises ArgumentError if parameter is negative or zero.
     def float(max : Float) : Float64
-      unless max > 0
-        raise ArgumentError.new "Invalid limit for float: #{max}"
-      end
+      Alea.sanity_check(max, :max, :float)
+      Alea.param_check(max, :<=, 0.0, :max, :float)
       @prng.next_f * max
     end
 
     # Generate a uniform-distributed `Float64` in a given range.
     def float(range : Range(Float, Float)) : Float64
+      Alea.sanity_check(range.begin, :left_bound, :float)
+      Alea.sanity_check(range.end, :right_bound, :float)
       unless range.begin <= range.end
-        raise ArgumentError.new "Invalid range for float: #{range}"
+        raise Alea::UndefinedError.new "Invalid value for `float': range = #{range}"
       end
       span = range.end - range.begin
       if range.excludes_end?
         if range.end == range.begin
-          raise ArgumentError.new "Invalid range for float: #{range}"
+          raise Alea::UndefinedError.new "Invalid value for `float': range = #{range}"
         end
       end
       @prng.next_f * span + range.begin


### PR DESCRIPTION
This PR adds an exception interface:
- now if `NaN` is passed as argument to methods a `Alea::NaNError` is raised;
- now if `Infinity` is passed as argument to methods a `Alea::InfinityError` is raised;
- now if a parameter does not match the conditions of a distribution a `Alea::UndefinedError` is raised;
- methods that had not converged in a fixed amount of tries raise a `Alea::NoConvergeError`

Raised messages tells where the issue comes from, the bad parameter's name and why the method would not expect that to be passed.

E.g.: this
```crystal
random = Alea::Random.new(28767)
a = random.normal 
b = random.normal
c = random.normal

random.lognormal(c)
random.beta(a: a, b: b)
```
will output:
```text
Invalid value for `beta': b = -0.09969585900795053 <= 0.0 (Alea::UndefinedError)
  from src/alea/rand/rbeta.cr:12:7 in 'beta:a:b'
  from spec/distributions/tests_spec.cr:9:7 in '->'
  from /usr/share/crystal/src/spec/example.cr:255:3 in 'internal_run'
  from /usr/share/crystal/src/spec/example.cr:35:16 in 'run'
  from /usr/share/crystal/src/spec/context.cr:296:23 in 'internal_run'
  from /usr/share/crystal/src/spec/context.cr:291:7 in 'run'
  from /usr/share/crystal/src/spec/context.cr:296:23 in 'internal_run'
  from /usr/share/crystal/src/spec/context.cr:291:7 in 'run'
  from /usr/share/crystal/src/spec/context.cr:48:23 in 'run'
  from /usr/share/crystal/src/spec/dsl.cr:270:7 in '->'
  from /usr/share/crystal/src/crystal/at_exit_handlers.cr:255:3 in 'run'
  from /usr/share/crystal/src/crystal/main.cr:45:14 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:114:3 in 'main'
  from __libc_start_main
  from _start
  from ???
```