### PR TITLE
Spec Macros

### DIFF
--- a/spec/prob/pchisq_spec.cr
+++ b/spec/prob/pchisq_spec.cr
@@ -4,48 +4,40 @@ describe Alea do
   context "ChiSquare" do
     describe Alea::CDF do
       describe "#chisq" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.chisq(0.0 / 0.0, df: 1.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :chisq,
+          params: {x: 1.0, df: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.chisq(1.0 / 0.0, df: 1.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :chisq,
+          params: {x: 1.0, df: 1.0},
+          params_to_check: [:x, :df],
+        )
 
-        it "raises Alea::NaNError if degrees of freedom are NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.chisq(0.0, df: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if degrees of freedom are Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.chisq(0.0, df: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if freedom is equal to 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.chisq(0.0, df: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if freedom is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.chisq(0.0, df: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :chisq,
+          params: {x: 1.0, df: 1.0},
+          params_to_check: [:df],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of -1.0 in X2(1)" do
-          Alea::CDF.chisq(-1.0).should eq(0.0)
+          Alea::CDF.chisq(-1.0, df: 1.0).should eq(0.0)
         end
 
         it "returns the cdf of 0.0 in X2(1)" do
-          Alea::CDF.chisq(0.0).should eq(0.0)
+          Alea::CDF.chisq(0.0, df: 1.0).should eq(0.0)
         end
 
         it "returns the cdf of 2.0 in X2(1)" do
@@ -53,7 +45,7 @@ describe Alea do
           tol = 1.0e-14
           # From WolframAlpha
           wf = 0.842700792949714869341
-          cv = Alea::CDF.chisq(2.0)
+          cv = Alea::CDF.chisq(2.0, df: 1.0)
           cv.should be_close(wf, cv * tol)
         end
 

--- a/spec/prob/pexp_spec.cr
+++ b/spec/prob/pexp_spec.cr
@@ -4,41 +4,33 @@ describe Alea do
   context "Exponential" do
     describe Alea::CDF do
       describe "#exp" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.exp(0.0 / 0.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :exp,
+          params: {x: 1.0, scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.exp(1.0 / 0.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :exp,
+          params: {x: 1.0, scale: 1.0},
+          params_to_check: [:x, :scale],
+        )
 
-        it "raises Alea::NaNError if scale is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.exp(1.0, scale: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if scale is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.exp(1.0, scale: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is 0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.exp(0.0, scale: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is negative" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.exp(0.0, scale: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :exp,
+          params: {x: 1.0, scale: 1.0},
+          params_to_check: [:scale],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of -1.0 in Exp(1.0)" do
           Alea::CDF.exp(-1.0).should eq(0.0)

--- a/spec/prob/pgamma_spec.cr
+++ b/spec/prob/pgamma_spec.cr
@@ -4,65 +4,33 @@ describe Alea do
   context "Gamma" do
     describe Alea::CDF do
       describe "#gamma" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.gamma(0.0 / 0.0, shape: 1.0, scale: 1.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :gamma,
+          params: {x: 1.0, shape: 1.0, scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.gamma(1.0 / 0.0, shape: 1.0, scale: 1.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :gamma,
+          params: {x: 1.0, shape: 1.0, scale: 1.0},
+          params_to_check: [:x, :shape, :scale],
+        )
 
-        it "raises Alea::NaNError if shape is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.gamma(0.0, shape: 0.0 / 0.0, scale: 1.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if shape is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.gamma(0.0, shape: 1.0 / 0.0, scale: 1.0)
-          end
-        end
-
-        it "raises Alea::NaNError if scale is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.gamma(0.0, shape: 1.0, scale: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if scale is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.gamma(0.0, shape: 1.0, scale: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if shape is 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.gamma(0.0, shape: 0.0, scale: 1.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if shape is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.gamma(0.0, shape: -1.0, scale: 1.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.gamma(0.0, shape: 1.0, scale: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.gamma(0.0, shape: 1.0, scale: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :gamma,
+          params: {x: 1.0, shape: 1.0, scale: 1.0},
+          params_to_check: [:shape, :scale],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of -1.0 in G(1, 1)" do
           Alea::CDF.gamma(-1.0, shape: 1.0, scale: 1.0).should eq(0.0)

--- a/spec/prob/plaplace_spec.cr
+++ b/spec/prob/plaplace_spec.cr
@@ -4,53 +4,33 @@ describe Alea do
   context "Laplace" do
     describe Alea::CDF do
       describe "#laplace" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.laplace(0.0 / 0.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :laplace,
+          params: {x: 1.0, loc: 1.0, scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.laplace(1.0 / 0.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :laplace,
+          params: {x: 1.0, loc: 1.0, scale: 1.0},
+          params_to_check: [:x, :loc, :scale],
+        )
 
-        it "raises Alea::NaNError if loc is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.laplace(1.0, loc: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if loc is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.laplace(1.0, loc: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::NaNError if scale is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.laplace(1.0, scale: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if scale is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.laplace(1.0, scale: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is equal to 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.laplace(0.0, scale: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.laplace(0.0, scale: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :laplace,
+          params: {x: 1.0, loc: 1.0, scale: 1.0},
+          params_to_check: [:scale],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of 0.0 in Laplace(0, 1)" do
           Alea::CDF.laplace(0.0).should eq(0.5)

--- a/spec/prob/plognor_spec.cr
+++ b/spec/prob/plognor_spec.cr
@@ -4,53 +4,33 @@ describe Alea do
   context "Lognormal" do
     describe Alea::CDF do
       describe "#lognormal" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.lognormal(0.0 / 0.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :lognormal,
+          params: {x: 1.0, loc: 1.0, sigma: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.lognormal(1.0 / 0.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :lognormal,
+          params: {x: 1.0, loc: 1.0, sigma: 1.0},
+          params_to_check: [:x, :loc, :sigma],
+        )
 
-        it "raises Alea::NaNError if loc is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.lognormal(0.0, loc: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if loc is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.lognormal(0.0, loc: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::NaNError if stdev is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.lognormal(0.0, sigma: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if stdev is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.lognormal(0.0, sigma: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if stdev is equal to 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.lognormal(0.0, sigma: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if stdev is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.lognormal(0.0, sigma: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :lognormal,
+          params: {x: 1.0, loc: 1.0, sigma: 1.0},
+          params_to_check: [:sigma],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of 0.0 in LogN(0, 1)" do
           Alea::CDF.lognormal(0.0).should eq(0.0)

--- a/spec/prob/pnorm_spec.cr
+++ b/spec/prob/pnorm_spec.cr
@@ -4,53 +4,33 @@ describe Alea do
   context "Normal" do
     describe Alea::CDF do
       describe "#normal" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.normal(0.0 / 0.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :normal,
+          params: {x: 1.0, loc: 1.0, sigma: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.normal(1.0 / 0.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :normal,
+          params: {x: 1.0, loc: 1.0, sigma: 1.0},
+          params_to_check: [:x, :loc, :sigma],
+        )
 
-        it "raises Alea::NaNError if loc is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.normal(0.0, loc: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if loc is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.normal(0.0, loc: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::NaNError if stdev is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.normal(0.0, sigma: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if stdev is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.normal(0.0, sigma: 1.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if stdev is equal to 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.normal(0.0, sigma: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if stdev is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.normal(0.0, sigma: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :normal,
+          params: {x: 1.0, loc: 1.0, sigma: 1.0},
+          params_to_check: [:sigma],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of 0.0 in N(0, 1)" do
           Alea::CDF.normal(0.0).should eq(0.5)

--- a/spec/prob/ppoiss_spec.cr
+++ b/spec/prob/ppoiss_spec.cr
@@ -4,29 +4,33 @@ describe Alea do
   context "Poisson" do
     describe Alea::CDF do
       describe "#poisson" do
-        it "raises Alea::NaNError if degrees of freedom are NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.poisson(0, lam: 0.0 / 0.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :poisson,
+          params: {k: 1, lam: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if degrees of freedom are Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.poisson(0, lam: 1.0 / 0.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :poisson,
+          params: {k: 1, lam: 1.0},
+          params_to_check: [:lam],
+        )
 
-        it "raises Alea::UndefinedError if freedom is equal to 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.poisson(0, lam: 0.0)
-          end
-        end
-
-        it "raises Alea::UndefinedError if freedom is less than 0.0" do
-          expect_raises Alea::UndefinedError do
-            Alea::CDF.poisson(0, lam: -1.0)
-          end
-        end
+        param_test(
+          caller: Alea::CDF,
+          method: :poisson,
+          params: {k: 1, lam: 1.0},
+          params_to_check: [:lam],
+          check_negatives: true,
+          check_zeros: true,
+        )
 
         it "returns the cdf of -1.0 in Poiss(1)" do
           Alea::CDF.poisson(-1).should eq(0.0)

--- a/spec/prob/punif_spec.cr
+++ b/spec/prob/punif_spec.cr
@@ -4,41 +4,24 @@ describe Alea do
   context "Uniform" do
     describe Alea::CDF do
       describe "#uniform" do
-        it "raises Alea::NaNError if x is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.uniform(0.0 / 0.0, min: 0.0, max: 1.0)
-          end
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          pending: true,
+          caller: Alea::CDF,
+          method: :uniform,
+          params: {x: 1.0, min: 1.0, max: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "raises Alea::InfinityError if x is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.uniform(1.0 / 0.0, min: 0.0, max: 1.0)
-          end
-        end
-
-        it "raises Alea::NaNError if min is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.uniform(0.0, min: 0.0 / 0.0, max: 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if min is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.uniform(0.0, min: 1.0 / 0.0, max: 0.0)
-          end
-        end
-
-        it "raises Alea::NaNError if max is NaN" do
-          expect_raises(Alea::NaNError) do
-            Alea::CDF.uniform(0.0, min: 0.0, max: 0.0 / 0.0)
-          end
-        end
-
-        it "raises Alea::InfinityError if max is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            Alea::CDF.uniform(0.0, min: 0.0, max: 1.0 / 0.0)
-          end
-        end
+        sanity_test(
+          caller: Alea::CDF,
+          method: :uniform,
+          params: {x: 1.0, min: 1.0, max: 1.0},
+          params_to_check: [:x, :min, :max],
+        )
 
         it "raises Alea::UndefinedError if min is equal to max" do
           expect_raises Alea::UndefinedError do

--- a/spec/rand/rbeta_spec.cr
+++ b/spec/rand/rbeta_spec.cr
@@ -4,112 +4,59 @@ describe Alea do
   context "Beta" do
     describe Alea::Random do
       describe "#beta" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.beta a: 1_i{{bits.id}}, b: 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :beta,
+          params: {a: 1.0, b: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.beta a: 1_u{{bits.id}}, b: 1_u{{bits.id}}
-          {% end %}
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :beta,
+          params: {a: 1.0, b: 1.0},
+          params_to_check: [:a, :b],
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.beta a: 1.0_f32, b: 1.0_f32
-          SpecRng.beta a: 1.0_f64, b: 1.0_f64
-        end
-
-        it "raises Alea::NaNError if a is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.beta a: 0.0 / 0.0, b: 1.0
-          end
-        end
-
-        it "raises Alea::InfinityError if a is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.beta a: 1.0 / 0.0, b: 1.0
-          end
-        end
-
-        it "raises Alea::NaNError if b is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.beta a: 1.0, b: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if b is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.beta a: 1.0, b: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if a is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.beta a: 0.0, b: 1.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if a is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.beta a: -1.0, b: 1.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if b is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.beta a: 1.0, b: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if b is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.beta a: 1.0, b: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :beta,
+          params: {a: 1.0, b: 1.0},
+          params_to_check: [:a, :b],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_beta" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_beta a: 1_i{{bits.id}}, b: 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 1.0, b: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_beta a: 1_u{{bits.id}}, b: 1_u{{bits.id}}
-          {% end %}
-        end
+        # mean  is:   1.0 / (1.0 + (b / a))
+        # stdev is:   sqrt( ab / ((a + b)^2 * (a + b + 1.0)) )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_beta a: 1.0_f32, b: 1.0_f32
-          SpecRng.next_beta a: 1.0_f64, b: 1.0_f64
-        end
-
-        it "generates beta-distributed random values with fixed a and b parameters" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_beta a: 3.0, b: 5.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   1.0 / (1.0 + (b / a))
-          # stdev is:   sqrt( ab / ((a + b)^2 * (a + b + 1.0)) )
-
-          mean_r = 0.375
-          stdev_r = 0.1613743060919757
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates beta-distributed random values with fixed a 3.0 and b 5.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 3.0, b: 5.0},
+          sample_type: Float64,
+          real_mean: 0.375,
+          real_stdev: 0.1613743060919757,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
       end
     end
   end

--- a/spec/rand/rbeta_spec.cr
+++ b/spec/rand/rbeta_spec.cr
@@ -57,6 +57,141 @@ describe Alea do
           mean_tol: 0.005,
           stdev_tol: 0.01,
         )
+
+        dist_test("generates beta-distributed random values with fixed a 0.1 and b 0.1 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 0.1, b: 0.1},
+          sample_type: Float64,
+          real_mean: 0.5,
+          real_stdev: 0.45643546458763845,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 0.0001 and b 0.0001 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 0.0001, b: 0.0001},
+          sample_type: Float64,
+          real_mean: 0.5,
+          real_stdev: 0.49995000749875024,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 0.0000001 and b 0.0000001 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 0.0000001, b: 0.0000001},
+          sample_type: Float64,
+          real_mean: 0.5,
+          real_stdev: 0.4999999500000075,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 0.001 and b 0.0000001 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 0.001, b: 0.0000001},
+          sample_type: Float64,
+          real_mean: 0.9999000099990001,
+          real_stdev: 0.009994003847242108,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 0.0000001 and b 0.001 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 0.0000001, b: 0.001},
+          sample_type: Float64,
+          real_mean: 9.999000099990002e-5,
+          real_stdev: 0.009994003847242108,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 1.0 and b 1.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 1.0, b: 1.0},
+          sample_type: Float64,
+          real_mean: 0.5,
+          real_stdev: 0.28867513459481287,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 1.0 and b 10.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 1.0, b: 10.0},
+          sample_type: Float64,
+          real_mean: 0.09090909090909091,
+          real_stdev: 0.08298826628866153,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 1.0 and b 100.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 1.0, b: 100.0},
+          sample_type: Float64,
+          real_mean: 0.009900990099009901,
+          real_stdev: 0.009803441019571034,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 1.0 and b 10_000.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 1.0, b: 10_000.0},
+          sample_type: Float64,
+          real_mean: 9.999000099990002e-5,
+          real_stdev: 9.99800034994001e-5,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 10.0 and b 1.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 10.0, b: 1.0},
+          sample_type: Float64,
+          real_mean: 0.9090909090909091,
+          real_stdev: 0.08298826628866153,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 100.0 and b 1.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 100.0, b: 1.0},
+          sample_type: Float64,
+          real_mean: 0.9900990099009901,
+          real_stdev: 0.009803441019571034,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates beta-distributed random values with fixed a 10_000.0 and b 1.0 parameters",
+          caller: SpecRng,
+          method: :next_beta,
+          params: {a: 10_000.0, b: 1.0},
+          sample_type: Float64,
+          real_mean: 0.9999000099990001,
+          real_stdev: 9.99800034994001e-5,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
       end
     end
   end

--- a/spec/rand/rchisq_spec.cr
+++ b/spec/rand/rchisq_spec.cr
@@ -4,88 +4,59 @@ describe Alea do
   context "ChiSquare" do
     describe Alea::Random do
       describe "#chisq" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.chisq 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :chisq,
+          params: {df: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.chisq 1_u{{bits.id}}
-          {% end %}
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :chisq,
+          params: {df: 1.0},
+          params_to_check: [:df],
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.chisq 1.0_f32
-          SpecRng.chisq 1.0_f64
-        end
-
-        it "raises Alea::NaNError if degrees of freedom are NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.chisq df: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if degrees of freedom are Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.chisq df: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if degrees of freedom are 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.chisq df: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if degrees of freedom are negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.chisq df: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :chisq,
+          params: {df: 1.0},
+          params_to_check: [:df],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_chisq" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_chisq 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_chisq 1_u{{bits.id}}
-          {% end %}
-        end
+        # mean  is:   k
+        # stdev is:   sqrt( 2k )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_chisq 1.0_f32
-          SpecRng.next_chisq 1.0_f64
-        end
-
-        it "generates chi^2-distributed random values with fixed degrees of freedom" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_chisq df: 3.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   k
-          # stdev is:   sqrt( 2k )
-
-          mean_r = 3.0
-          stdev_r = 2.449489742783178
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates chi^2-distributed random values with fixed df 3.0",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 3.0},
+          sample_type: Float64,
+          real_mean: 3.0,
+          real_stdev: 2.449489742783178,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
       end
     end
   end

--- a/spec/rand/rchisq_spec.cr
+++ b/spec/rand/rchisq_spec.cr
@@ -47,13 +47,68 @@ describe Alea do
         # mean  is:   k
         # stdev is:   sqrt( 2k )
 
-        dist_test("generates chi^2-distributed random values with fixed df 3.0",
+        dist_test("generates chi^2-distributed random values with fixed df 1.0 parameter",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 1.0},
+          sample_type: Float64,
+          real_mean: 1.0,
+          real_stdev: 1.4142135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates chi^2-distributed random values with fixed df 3.0 parameter",
           caller: SpecRng,
           method: :next_chisq,
           params: {df: 3.0},
           sample_type: Float64,
           real_mean: 3.0,
           real_stdev: 2.449489742783178,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates chi^2-distributed random values with fixed df 10.0 parameter",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 10.0},
+          sample_type: Float64,
+          real_mean: 10.0,
+          real_stdev: 4.47213595499958,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates chi^2-distributed random values with fixed df 100.0 parameter",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 100.0},
+          sample_type: Float64,
+          real_mean: 100.0,
+          real_stdev: 14.142135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates chi^2-distributed random values with fixed df 1_000.0 parameter",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 1_000.0},
+          sample_type: Float64,
+          real_mean: 1_000.0,
+          real_stdev: 44.721359549995796,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates chi^2-distributed random values with fixed df 10_000.0 parameter",
+          caller: SpecRng,
+          method: :next_chisq,
+          params: {df: 10_000.0},
+          sample_type: Float64,
+          real_mean: 10_000.0,
+          real_stdev: 141.4213562373095,
           mean_tol: 0.005,
           stdev_tol: 0.01,
         )

--- a/spec/rand/rexp_spec.cr
+++ b/spec/rand/rexp_spec.cr
@@ -4,111 +4,69 @@ describe Alea do
   context "Exponential" do
     describe Alea::Random do
       describe "#exp" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.exp 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :exp,
+          params: {scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.exp 1_u{{bits.id}}
-          {% end %}
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :exp,
+          params: {scale: 1.0},
+          params_to_check: [:scale],
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.exp 1.0_f32
-          SpecRng.exp 1.0_f64
-        end
-
-        it "raises Alea::NaNError if a is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.exp scale: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if a is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.exp scale: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.exp scale: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.exp scale: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :exp,
+          params: {scale: 1.0},
+          params_to_check: [:scale],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_exp" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_exp 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_exp 1_u{{bits.id}}
-          {% end %}
-        end
+        # mean  is:   k
+        # stdev is:   k
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_exp 1.0_f32
-          SpecRng.next_exp 1.0_f64
-        end
+        dist_test("generates exp-distributed random values with fixed scale 1.0",
+          caller: SpecRng,
+          method: :next_exp,
+          sample_type: Float64,
+          real_mean: 1.0,
+          real_stdev: 1.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
 
-        it "generates exp-distributed random values with scale 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_exp
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   k
-          # stdev is:   k
-
-          mean_r = 1.0
-          stdev_r = 1.0
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates exp-distributed random values with fixed scale" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_exp scale: 3.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   k
-          # stdev is:   k
-
-          mean_r = 3.0
-          stdev_r = 3.0
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates exp-distributed random values with fixed scale 3.0",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 3.0},
+          sample_type: Float64,
+          real_mean: 3.0,
+          real_stdev: 3.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
       end
     end
   end

--- a/spec/rand/rexp_spec.cr
+++ b/spec/rand/rexp_spec.cr
@@ -47,7 +47,51 @@ describe Alea do
         # mean  is:   k
         # stdev is:   k
 
-        dist_test("generates exp-distributed random values with fixed scale 1.0",
+        dist_test("generates exp-distributed random values with fixed scale 0.1 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 0.1},
+          sample_type: Float64,
+          real_mean: 0.1,
+          real_stdev: 0.1,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 0.01 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 0.01},
+          sample_type: Float64,
+          real_mean: 0.01,
+          real_stdev: 0.01,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 0.00001 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 0.00001},
+          sample_type: Float64,
+          real_mean: 0.00001,
+          real_stdev: 0.00001,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 0.00000000001 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 0.00000000001},
+          sample_type: Float64,
+          real_mean: 0.00000000001,
+          real_stdev: 0.00000000001,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 1.0 parameter",
           caller: SpecRng,
           method: :next_exp,
           sample_type: Float64,
@@ -57,13 +101,57 @@ describe Alea do
           stdev_tol: 0.01,
         )
 
-        dist_test("generates exp-distributed random values with fixed scale 3.0",
+        dist_test("generates exp-distributed random values with fixed scale 3.0 parameter",
           caller: SpecRng,
           method: :next_exp,
           params: {scale: 3.0},
           sample_type: Float64,
           real_mean: 3.0,
           real_stdev: 3.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 10.0 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 10.0},
+          sample_type: Float64,
+          real_mean: 10.0,
+          real_stdev: 10.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 100.0 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 100.0},
+          sample_type: Float64,
+          real_mean: 100.0,
+          real_stdev: 100.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 1_000.0 parameter",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 1_000.0},
+          sample_type: Float64,
+          real_mean: 1_000.0,
+          real_stdev: 1_000.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates exp-distributed random values with fixed scale 10_000.0",
+          caller: SpecRng,
+          method: :next_exp,
+          params: {scale: 10_000.0},
+          sample_type: Float64,
+          real_mean: 10_000.0,
+          real_stdev: 10_000.0,
           mean_tol: 0.005,
           stdev_tol: 0.01,
         )

--- a/spec/rand/rgamma_spec.cr
+++ b/spec/rand/rgamma_spec.cr
@@ -47,6 +47,141 @@ describe Alea do
         # mean  is:   ks
         # stdev is:   sqrt( ks^2 )
 
+        dist_test("generates gamma-distributed random values with fixed shape 0.1 and scale 0.1 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 0.1, scale: 0.1},
+          sample_type: Float64,
+          real_mean: 0.01,
+          real_stdev: 0.0316227766016838,
+          mean_tol: 0.005,
+          stdev_tol: 0.05,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 0.0001 and scale 0.0001 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 0.0001, scale: 0.0001},
+          sample_type: Float64,
+          real_mean: 0.00000001,
+          real_stdev: 1.0e-6,
+          mean_tol: 0.005,
+          stdev_tol: 0.2,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 0.0000001 and scale 0.0000001 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 0.0000001, scale: 0.0000001},
+          sample_type: Float64,
+          real_mean: 1.0e-16,
+          real_stdev: 3.162277660168379e-11,
+          mean_tol: 0.005,
+          stdev_tol: 0.2,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 0.001 and scale 0.0000001 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 0.001, scale: 0.0000001},
+          sample_type: Float64,
+          real_mean: 1.0e-10,
+          real_stdev: 3.162277660168379e-9,
+          mean_tol: 0.005,
+          stdev_tol: 0.05,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 0.0000001 and scale 0.001 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 0.0000001, scale: 0.001},
+          sample_type: Float64,
+          real_mean: 1.0e-10,
+          real_stdev: 3.162277660168379e-7,
+          mean_tol: 0.005,
+          stdev_tol: 0.05,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 1.0 and scale 1.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 1.0, scale: 1.0},
+          sample_type: Float64,
+          real_mean: 1.0,
+          real_stdev: 1.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 1.0 and scale 10.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 1.0, scale: 10.0},
+          sample_type: Float64,
+          real_mean: 10.0,
+          real_stdev: 10.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 1.0 and scale 100.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 1.0, scale: 100.0},
+          sample_type: Float64,
+          real_mean: 100.0,
+          real_stdev: 100.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 1.0 and scale 10_000.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 1.0, scale: 10_000.0},
+          sample_type: Float64,
+          real_mean: 10_000.0,
+          real_stdev: 10_000.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 10.0 and scale 1.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 10.0, scale: 1.0},
+          sample_type: Float64,
+          real_mean: 10.0,
+          real_stdev: 3.1622776601683795,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 100.0 and scale 1.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 100.0, scale: 1.0},
+          sample_type: Float64,
+          real_mean: 100.0,
+          real_stdev: 10.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates gamma-distributed random values with fixed shape 10_000.0 and scale 1.0 parameters",
+          caller: SpecRng,
+          method: :next_gamma,
+          params: {shape: 10_000.0, scale: 1.0},
+          sample_type: Float64,
+          real_mean: 10_000.0,
+          real_stdev: 100.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
         dist_test("generates gamma-distributed random values with fixed shape 3.0 and scale 1.0 parameters",
           caller: SpecRng,
           method: :next_gamma,

--- a/spec/rand/rlaplace_spec.cr
+++ b/spec/rand/rlaplace_spec.cr
@@ -47,6 +47,50 @@ describe Alea do
         # mean  is:   m
         # stdev is:   k * sqrt( 2 )
 
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 0.1 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 0.1},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 0.14142135623730953,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 0.01 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 0.01},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 0.014142135623730952,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 0.00001 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 0.00001},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1.4142135623730953e-5,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 0.00000000001 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 0.00000000001},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1.414213562373095e-11,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
         dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 1.0 parameters",
           caller: SpecRng,
           method: :next_laplace,
@@ -75,6 +119,72 @@ describe Alea do
           sample_type: Float64,
           real_mean: 3.0,
           real_stdev: 2.121320343559643,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 10.0 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 10.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 14.142135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 100.0 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 100.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 141.42135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 1_000.0 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 1_000.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1414.2135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 10_000.0 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 0.0, scale: 10_000.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 14142.135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc 93.0 and scale 0.5 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 93.0, scale: 0.5},
+          sample_type: Float64,
+          real_mean: 93.0,
+          real_stdev: 0.7071067811865476,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates laplace-distributed random values with fixed loc -93.0 and scale 0.5 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: -93.0, scale: 0.5},
+          sample_type: Float64,
+          real_mean: -93.0,
+          real_stdev: 0.7071067811865476,
           mean_tol: 0.005,
           stdev_tol: 0.005,
         )

--- a/spec/rand/rlaplace_spec.cr
+++ b/spec/rand/rlaplace_spec.cr
@@ -4,156 +4,80 @@ describe Alea do
   context "Laplace" do
     describe Alea::Random do
       describe "#laplace" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.laplace 1_i{{bits.id}}
-            SpecRng.laplace 1_i{{bits.id}}, 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :laplace,
+          params: {loc: 1.0, scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.laplace 1_u{{bits.id}}
-            SpecRng.laplace 1_u{{bits.id}}, 1_u{{bits.id}}
-          {% end %}
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :laplace,
+          params: {loc: 1.0, scale: 1.0},
+          params_to_check: [:loc, :scale],
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.laplace 1.0_f32
-          SpecRng.laplace 1.0_f64
-
-          SpecRng.laplace 1.0_f32, 1.0_f32
-          SpecRng.laplace 1.0_f64, 1.0_f64
-        end
-
-        it "raises Alea::NaNError if loc is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.laplace loc: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if loc is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.laplace loc: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::NaNError if scale NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.laplace 1.0, scale: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if scale Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.laplace 1.0, scale: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.laplace 1.0, scale: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if scale is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.laplace 1.0, scale: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :laplace,
+          params: {loc: 1.0, scale: 1.0},
+          params_to_check: [:scale],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_laplace" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_laplace 1_i{{bits.id}}
-            SpecRng.next_laplace 1_i{{bits.id}}, 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 1.0, scale: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_laplace 1_u{{bits.id}}
-            SpecRng.next_laplace 1_u{{bits.id}}, 1_u{{bits.id}}
-          {% end %}
-        end
+        # mean  is:   m
+        # stdev is:   k * sqrt( 2 )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_laplace 1.0_f32
-          SpecRng.next_laplace 1.0_f64
+        dist_test("generates laplace-distributed random values with fixed loc 0.0 and scale 1.0 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1.4142135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          SpecRng.next_laplace 1.0_f32, 1.0_f32
-          SpecRng.next_laplace 1.0_f64, 1.0_f64
-        end
+        dist_test("generates laplace-distributed random values with fixed loc 3.0 and scale 1.0 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 3.0},
+          sample_type: Float64,
+          real_mean: 3.0,
+          real_stdev: 1.4142135623730951,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-        it "generates laplace-distributed random values with loc 0.0 and scale 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_laplace
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   m
-          # stdev is:   k * sqrt( 2 )
-
-          mean_r = 0.0
-          stdev_r = 1.4142135623730951
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates laplace-distributed random values with fixed loc and scale 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_laplace loc: 3.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   m
-          # stdev is:   k * sqrt( 2 )
-
-          mean_r = 3.0
-          stdev_r = 1.4142135623730951
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates laplace-distributed random values with fixed shape and fixed scale" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_laplace loc: 3.0, scale: 1.5
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   m
-          # stdev is:   k * sqrt( 2 )
-
-          mean_r = 3.0
-          stdev_r = 2.121320343559643
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates laplace-distributed random values with fixed loc 3.0 and scale 1.5 parameters",
+          caller: SpecRng,
+          method: :next_laplace,
+          params: {loc: 3.0, scale: 1.5},
+          sample_type: Float64,
+          real_mean: 3.0,
+          real_stdev: 2.121320343559643,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
       end
     end
   end

--- a/spec/rand/rlognor_spec.cr
+++ b/spec/rand/rlognor_spec.cr
@@ -47,7 +47,52 @@ describe Alea do
         # mean  is:   exp( m + s^2 / 2 )
         # stdev is:   sqrt( exp(2m + s^2) * (exp(s^2) - 1) )
 
-        dist_test("generates lognormal-distributed random values with fixed loc 0.0 and sigma 1.0 parameters",
+        dist_test("generates log-normal-distributed random values with fixed loc 0.0 and sigma 0.1 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 0.0, sigma: 0.1},
+          sample_type: Float64,
+          real_mean: 1.005012520859401,
+          real_stdev: 0.10075302944620396,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
+
+        dist_test("generates log-normal-distributed random values with fixed loc 0.0 and sigma 0.01 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 0.0, sigma: 0.01},
+          sample_type: Float64,
+          real_mean: 1.0000500012500209,
+          real_stdev: 0.010000750030211357,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
+
+        dist_test("generates log-normal-distributed random values with fixed loc 0.0 and sigma 0.00001 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 0.0, sigma: 0.00001},
+          sample_type: Float64,
+          real_mean: 1.00000000005,
+          real_stdev: 1.0000000414201846e-5,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
+
+        dist_test("generates log-normal-distributed random values with fixed loc 0.0 and sigma 10.0 parameters",
+          pending: true,
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 0.0, sigma: 10.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 2.6881171418161356e+43,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
+
+        dist_test("generates log-normal-distributed random values with fixed loc 0.0 and sigma 1.0 parameters",
           caller: SpecRng,
           method: :next_lognormal,
           sample_type: Float64,
@@ -57,7 +102,7 @@ describe Alea do
           stdev_tol: 0.007,
         )
 
-        dist_test("generates lognormal-distributed random values with fixed loc 3.0 and sigma 1.0 parameters",
+        dist_test("generates log-normal-distributed random values with fixed loc 3.0 and sigma 1.0 parameters",
           caller: SpecRng,
           method: :next_lognormal,
           params: {loc: 3.0},
@@ -68,7 +113,7 @@ describe Alea do
           stdev_tol: 0.007,
         )
 
-        dist_test("generates lognormal-distributed random values with fixed loc 3.0 and sigma 0.5 parameters",
+        dist_test("generates log-normal-distributed random values with fixed loc 3.0 and sigma 0.5 parameters",
           caller: SpecRng,
           method: :next_lognormal,
           params: {loc: 3.0, sigma: 0.5},
@@ -79,7 +124,7 @@ describe Alea do
           stdev_tol: 0.007,
         )
 
-        dist_test("generates lognormal-distributed random values with fixed loc -3.0 and sigma 0.5 parameters",
+        dist_test("generates log-normal-distributed random values with fixed loc -3.0 and sigma 0.5 parameters",
           caller: SpecRng,
           method: :next_lognormal,
           params: {loc: -3.0, sigma: 0.5},

--- a/spec/rand/rlognor_spec.cr
+++ b/spec/rand/rlognor_spec.cr
@@ -4,179 +4,91 @@ describe Alea do
   context "Lognormal" do
     describe Alea::Random do
       describe "#lognormal" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.lognormal 1_i{{bits.id}}
-            SpecRng.lognormal 1_i{{bits.id}}, 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :lognormal,
+          params: {loc: 1.0, sigma: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.lognormal 1_u{{bits.id}}
-            SpecRng.lognormal 1_u{{bits.id}}, 1_u{{bits.id}}
-          {% end %}
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :lognormal,
+          params: {loc: 1.0, sigma: 1.0},
+          params_to_check: [:loc, :sigma],
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.lognormal 1.0_f32
-          SpecRng.lognormal 1.0_f64
-
-          SpecRng.lognormal 1.0_f32, 1.0_f32
-          SpecRng.lognormal 1.0_f64, 1.0_f64
-        end
-
-        it "raises Alea::NaNError if loc is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.lognormal loc: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if loc is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.lognormal loc: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::NaNError if sigma NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.lognormal 1.0, sigma: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if sigma Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.lognormal 1.0, sigma: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if sigma is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.lognormal sigma: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if sigma is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.lognormal sigma: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :lognormal,
+          params: {loc: 1.0, sigma: 1.0},
+          params_to_check: [:sigma],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_lognormal" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_lognormal 1_i{{bits.id}}
-            SpecRng.next_lognormal 1_i{{bits.id}}, 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 1.0, sigma: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_lognormal 1_u{{bits.id}}
-            SpecRng.next_lognormal 1_u{{bits.id}}, 1_u{{bits.id}}
-          {% end %}
-        end
+        # mean  is:   exp( m + s^2 / 2 )
+        # stdev is:   sqrt( exp(2m + s^2) * (exp(s^2) - 1) )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_lognormal 1.0_f32
-          SpecRng.next_lognormal 1.0_f64
+        dist_test("generates lognormal-distributed random values with fixed loc 0.0 and sigma 1.0 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          sample_type: Float64,
+          real_mean: 1.6487212707001282,
+          real_stdev: 2.1611974158950877,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
 
-          SpecRng.next_lognormal 1.0_f32, 1.0_f32
-          SpecRng.next_lognormal 1.0_f64, 1.0_f64
-        end
+        dist_test("generates lognormal-distributed random values with fixed loc 3.0 and sigma 1.0 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 3.0},
+          sample_type: Float64,
+          real_mean: 33.11545195869231,
+          real_stdev: 43.40881049525856,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
 
-        it "generates lognormal-distributed random values with underlying normal with loc 0.0 and stdev 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
+        dist_test("generates lognormal-distributed random values with fixed loc 3.0 and sigma 0.5 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: 3.0, sigma: 0.5},
+          sample_type: Float64,
+          real_mean: 22.75989509352673,
+          real_stdev: 12.129666457739873,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
 
-          SpecNdata.times do
-            ran = SpecRng.next_lognormal
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   exp( m + s^2 / 2 )
-          # stdev is:   sqrt( exp(2m + s^2) * (exp(s^2) - 1) )
-
-          mean_r = 1.6487212707001282
-          stdev_r = 2.1611974158950877
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, 0.007 * stdev_r)
-        end
-
-        it "generates lognormal-distributed random values with underlying normal with fixed loc and stdev 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_lognormal loc: 3.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   exp( m + s^2 / 2 )
-          # stdev is:   sqrt( exp(2m + s^2) * (exp(s^2) - 1) )
-
-          mean_r = 33.11545195869231
-          stdev_r = 43.40881049525856
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, 0.007 * stdev_r)
-        end
-
-        it "generates lognormal-distributed random values with underlying normal with fixed loc and fixed stdev" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_lognormal loc: 3.0, sigma: 0.5
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   exp( m + s^2 / 2 )
-          # stdev is:   sqrt( exp(2m + s^2) * (exp(s^2) - 1) )
-
-          mean_r = 22.75989509352673
-          stdev_r = 12.129666457739873
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, 0.007 * stdev_r)
-        end
-
-        it "generates lognormal-distributed random values with underlying normal with negative fixed loc and fixed stdev" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_lognormal loc: -3.0, sigma: 0.5
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   exp( m + s^2 / 2 )
-          # stdev is:   sqrt( exp(2m + s^2) * (exp(s^2) - 1) )
-
-          mean_r = 0.05641613950377735
-          stdev_r = 0.03006643713435963
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, 0.007 * stdev_r)
-        end
+        dist_test("generates lognormal-distributed random values with fixed loc -3.0 and sigma 0.5 parameters",
+          caller: SpecRng,
+          method: :next_lognormal,
+          params: {loc: -3.0, sigma: 0.5},
+          sample_type: Float64,
+          real_mean: 0.05641613950377735,
+          real_stdev: 0.03006643713435963,
+          mean_tol: 0.005,
+          stdev_tol: 0.007,
+        )
       end
     end
   end

--- a/spec/rand/rnorm_spec.cr
+++ b/spec/rand/rnorm_spec.cr
@@ -4,167 +4,91 @@ describe Alea do
   context "Normal" do
     describe Alea::Random do
       describe "#normal" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.normal 1_i{{bits.id}}
-            SpecRng.normal 1_i{{bits.id}}, 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :normal,
+          params: {loc: 1.0, sigma: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.normal 1_u{{bits.id}}
-            SpecRng.normal 1_u{{bits.id}}, 1_u{{bits.id}}
-          {% end %}
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :normal,
+          params: {loc: 1.0, sigma: 1.0},
+          params_to_check: [:loc, :sigma],
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.normal 1.0_f32
-          SpecRng.normal 1.0_f64
-
-          SpecRng.normal 1.0_f32, 1.0_f32
-          SpecRng.normal 1.0_f64, 1.0_f64
-        end
-
-        it "raises Alea::NaNError if loc is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.normal loc: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if loc is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.normal loc: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::NaNError if sigma NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.normal 1.0, sigma: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if sigma Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.normal 1.0, sigma: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if sigma is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.normal sigma: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if sigma is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.normal sigma: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :normal,
+          params: {loc: 1.0, sigma: 1.0},
+          params_to_check: [:sigma],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_normal" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_normal 1_i{{bits.id}}
-            SpecRng.next_normal 1_i{{bits.id}}, 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 1.0, sigma: 1.0},
+          return_type: Float64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_normal 1_u{{bits.id}}
-            SpecRng.next_normal 1_u{{bits.id}}, 1_u{{bits.id}}
-          {% end %}
-        end
+        # mean  is:   m
+        # stdev is:   s
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_normal 1.0_f32
-          SpecRng.next_normal 1.0_f64
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 1.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          SpecRng.next_normal 1.0_f32, 1.0_f32
-          SpecRng.next_normal 1.0_f64, 1.0_f64
-        end
+        dist_test("generates normal-distributed random values with fixed loc 3.0 and sigma 1.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 3.0},
+          sample_type: Float64,
+          real_mean: 3.0,
+          real_stdev: 1.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-        it "generates normal-distributed random values with loc 0.0 and stdev 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
+        dist_test("generates normal-distributed random values with fixed loc 93.0 and sigma 0.5 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 93.0, sigma: 0.5},
+          sample_type: Float64,
+          real_mean: 93.0,
+          real_stdev: 0.5,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          SpecNdata.times do
-            ran = SpecRng.next_normal
-            ans += ran
-            ary << ran
-          end
-
-          mean_r = 0.0
-          stdev_r = 1.0
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates normal-distributed random values with fixed loc and stdev 1.0" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_normal loc: 93.0
-            ans += ran
-            ary << ran
-          end
-
-          mean_r = 93.0
-          stdev_r = 1.0
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates normal-distributed random values with fixed loc and fixed stdev" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_normal loc: 93.0, sigma: 9.3
-            ans += ran
-            ary << ran
-          end
-
-          mean_r = 93.0
-          stdev_r = 9.3
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates normal-distributed random values with negative fixed loc and fixed stdev" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_normal loc: -93.0, sigma: 9.3
-            ans += ran
-            ary << ran
-          end
-
-          mean_r = -93.0
-          stdev_r = 9.3
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates normal-distributed random values with fixed loc -93.0 and sigma 0.5 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: -93.0, sigma: 0.5},
+          sample_type: Float64,
+          real_mean: -93.0,
+          real_stdev: 0.5,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
       end
     end
   end

--- a/spec/rand/rnorm_spec.cr
+++ b/spec/rand/rnorm_spec.cr
@@ -47,6 +47,115 @@ describe Alea do
         # mean  is:   m
         # stdev is:   s
 
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 0.1 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 0.1},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 0.1,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 0.01 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 0.01},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 0.01,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 0.00001 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 0.00001},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 0.00001,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 0.00000000001 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 0.00000000001},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 0.00000000001,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 1.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 3.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 3.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 3.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 10.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 10.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 10.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 100.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 100.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 100.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 1_000.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 1_000.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 1_000.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 10_000.0 parameters",
+          caller: SpecRng,
+          method: :next_normal,
+          params: {loc: 0.0, sigma: 10_000.0},
+          sample_type: Float64,
+          real_mean: 0.0,
+          real_stdev: 10_000.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
         dist_test("generates normal-distributed random values with fixed loc 0.0 and sigma 1.0 parameters",
           caller: SpecRng,
           method: :next_normal,

--- a/spec/rand/rpoiss_spec.cr
+++ b/spec/rand/rpoiss_spec.cr
@@ -51,6 +51,53 @@ describe Alea do
           SpecRng.next_poisson(lam: 0.0).should eq(0.0)
         end
 
+        dist_test("generates poisson-distributed random values with fixed lam 0.1 parameter",
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 0.1},
+          sample_type: Int64,
+          real_mean: 0.1,
+          real_stdev: 0.31622776601683794,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
+
+        dist_test("generates poisson-distributed random values with fixed lam 0.01 parameter",
+          pending: true,
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 0.01},
+          sample_type: Int64,
+          real_mean: 0.01,
+          real_stdev: 0.1,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates poisson-distributed random values with fixed lam 0.0001 parameter",
+          pending: true,
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 0.0001},
+          sample_type: Int64,
+          real_mean: 0.0001,
+          real_stdev: 0.01,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
+        dist_test("generates poisson-distributed random values with fixed lam 0.0000001 parameter",
+          pending: true,
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 0.0000001},
+          sample_type: Int64,
+          real_mean: 0.0000001,
+          real_stdev: 0.00031622776601683794,
+          mean_tol: 0.005,
+          stdev_tol: 0.01,
+        )
+
         dist_test("generates poisson-distributed random values with fixed lam 1.0 parameter",
           caller: SpecRng,
           method: :next_poisson,

--- a/spec/rand/rpoiss_spec.cr
+++ b/spec/rand/rpoiss_spec.cr
@@ -4,143 +4,95 @@ describe Alea do
   context "Poisson" do
     describe Alea::Random do
       describe "#poisson" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.poisson 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :poisson,
+          params: {lam: 1.0},
+          return_type: Int64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.poisson 1.0_f32
-          SpecRng.poisson 1.0_f64
-        end
+        sanity_test(
+          caller: SpecRng,
+          method: :poisson,
+          params: {lam: 1.0},
+          params_to_check: [:lam],
+        )
 
-        it "raises Alea::InfinityError if lambda is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.poisson lam: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if lambda is 0.0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.poisson lam: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if lambda is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.poisson lam: -1.0
-          end
-        end
+        param_test(
+          caller: SpecRng,
+          method: :poisson,
+          params: {lam: 1.0},
+          params_to_check: [:lam],
+          check_negatives: true,
+          check_zeros: true,
+        )
       end
 
       describe "#next_poisson" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.next_poisson 1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt/Float as argument(s)",
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 1.0},
+          return_type: Int64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+                  Float32, Float64,
+          ]
+        )
 
-        it "accepts any sized Float as argument(s)" do
-          SpecRng.next_poisson 1.0_f32
-          SpecRng.next_poisson 1.0_f64
-        end
+        # mean  is:   l
+        # stdev is:   sqrt( l )
 
         it "returns 0.0 if lambda is 0.0" do
           SpecRng.next_poisson(lam: 0.0).should eq(0.0)
         end
 
-        it "generates poisson-distributed random values with lambda 1.0" do
-          ary = Array(Int64).new
-          ans = 0.0
+        dist_test("generates poisson-distributed random values with fixed lam 1.0 parameter",
+          caller: SpecRng,
+          method: :next_poisson,
+          sample_type: Int64,
+          real_mean: 1.0,
+          real_stdev: 1.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          SpecNdata.times do
-            ran = SpecRng.next_poisson
-            ans += ran
-            ary << ran
-          end
+        dist_test("generates poisson-distributed random values with fixed lam 3.0 parameter",
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 3.0},
+          sample_type: Int64,
+          real_mean: 3.0,
+          real_stdev: 1.7320508075688772,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          # mean  is:   l
-          # stdev is:   sqrt( l )
+        dist_test("generates poisson-distributed random values with fixed lam 10.0 parameter",
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 10.0},
+          sample_type: Int64,
+          real_mean: 10.0,
+          real_stdev: 3.1622776601683795,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          mean_r = 1.0
-          stdev_r = 1.0
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates poisson-distributed random values with fixed lambda below 7.0" do
-          ary = Array(Int64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_poisson lam: 3.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   l
-          # stdev is:   sqrt( l )
-
-          mean_r = 3.0
-          stdev_r = 1.7320508075688772
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates poisson-distributed random values with fixed lambda = 10.0" do
-          ary = Array(Int64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_poisson lam: 10.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   l
-          # stdev is:   sqrt( l )
-
-          mean_r = 10.0
-          stdev_r = 3.1622776601683795
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "generates poisson-distributed random values with fixed lambda above 10.0" do
-          ary = Array(Int64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.next_poisson lam: 937793773973.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   l
-          # stdev is:   sqrt( l )
-
-          mean_r = 937793773973.0
-          stdev_r = 968397.5288965787
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates poisson-distributed random values with fixed lam 10_000.0 parameter",
+          caller: SpecRng,
+          method: :next_poisson,
+          params: {lam: 10_000.0},
+          sample_type: Int64,
+          real_mean: 10_000.0,
+          real_stdev: 100.0,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
       end
     end
   end

--- a/spec/rand/runif_spec.cr
+++ b/spec/rand/runif_spec.cr
@@ -4,30 +4,30 @@ describe Alea do
   context "Uniform" do
     describe Alea::Random do
       describe "#uint" do
-        it "accepts any sized Int as argument(s)" do
-          {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.uint 1_i{{bits.id}}
-            SpecRng.uint 1_i{{bits.id}}..1_i{{bits.id}}
-          {% end %}
-        end
+        arg_test("accepts any sized Int/UInt as argument(s)",
+          caller: SpecRng,
+          method: :uint,
+          params: {max: 1},
+          return_type: UInt64,
+          types: [Int8, Int16, Int32, Int64, Int128,
+                  UInt8, UInt16, UInt32, UInt64, UInt128,
+          ]
+        )
 
-        it "accepts any sized UInt as argument(s)" do
+        param_test(
+          caller: SpecRng,
+          method: :uint,
+          params: {max: 1},
+          params_to_check: [:max],
+          check_negatives: true,
+          check_zeros: true,
+        )
+
+        it "accepts any sized Range as argument" do
           {% for bits in %i[8 16 32 64 128] %}
-            SpecRng.uint 1_u{{bits.id}}
+            SpecRng.uint 1_i{{bits.id}}..1_i{{bits.id}}
             SpecRng.uint 1_u{{bits.id}}..1_u{{bits.id}}
           {% end %}
-        end
-
-        it "raises Alea::UndefinedError if max is 0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.uint max: 0
-          end
-        end
-
-        it "raises Alea::UndefinedError if max is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.uint max: -1
-          end
         end
 
         it "raises Alea::UndefinedError if range is negative" do
@@ -60,106 +60,78 @@ describe Alea do
           SpecRng.uint(0..0).should eq(0)
         end
 
-        it "returns uniformly-distributed random values with fixed limit" do
-          ary = Array(UInt64).new
-          ans = 0.0
+        # mean  is:   a / 2
+        # stdev is:   a / sqrt( 12 )
 
-          SpecNdata.times do
-            ran = SpecRng.uint 9377
-            ans += ran
-            ary << ran
-          end
+        dist_test("generates uniform-distributed random values with fixed max 9377 parameter",
+          caller: SpecRng,
+          method: :uint,
+          params: {max: 9377},
+          sample_type: UInt64,
+          real_mean: 4688.5,
+          real_stdev: 2706.9067370955604,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          # mean  is:   a / 2
-          # stdev is:   a / sqrt( 12 )
+        dist_test("generates uniform-distributed random values with fixed range 10..93 parameter",
+          caller: SpecRng,
+          method: :uint,
+          params: {range: 10..93},
+          sample_type: UInt64,
+          real_mean: 51.5,
+          real_stdev: 24.248711305964285,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          mean_r = 4688.5
-          stdev_r = 2706.9067370955604
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "returns uniformly-distributed random values with fixed range inclusive" do
-          ary = Array(UInt64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.uint 10..93
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   (b + a) / 2
-          # stdev is:   (b - a) / sqrt( 12 )
-
-          mean_r = 51.5
-          stdev_r = 24.248711305964285
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "returns uniformly-distributed random values with fixed range exclusive" do
-          ary = Array(UInt64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.uint 10...93
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   (b + a) / 2
-          # stdev is:   (b - a) / sqrt( 12 )
-
-          mean_r = 51.0
-          stdev_r = 23.96003617136947
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates uniform-distributed random values with fixed range 10...93 parameter",
+          caller: SpecRng,
+          method: :uint,
+          params: {range: 10...93},
+          sample_type: UInt64,
+          real_mean: 51.0,
+          real_stdev: 23.96003617136947,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
       end
 
       describe "#float" do
-        it "accepts any sized Float as argument(s)" do
+        arg_test("accepts any sized Float as argument(s)",
+          caller: SpecRng,
+          method: :float,
+          params: {max: 1.0},
+          return_type: Float64,
+          types: [Float32, Float64]
+        )
+
+        sanity_test(
+          caller: SpecRng,
+          method: :float,
+          params: {max: 1.0},
+          params_to_check: [:max],
+        )
+
+        param_test(
+          caller: SpecRng,
+          method: :float,
+          params: {max: 1.0},
+          params_to_check: [:max],
+          check_negatives: true,
+          check_zeros: true,
+        )
+
+        it "accepts any sized Range as argument" do
+          # TODO: uncomment when `float` accepts Int arguments
+          # {% for bits in %i[8 16 32 64 128] %}
+          #   SpecRng.float 1_i{{bits.id}}..1_i{{bits.id}}
+          #   SpecRng.float 1_u{{bits.id}}..1_u{{bits.id}}
+          # {% end %}
+
           {% for bits in %i[32 64] %}
-            SpecRng.float 1.0_f{{bits.id}}
             SpecRng.float 1.0_f{{bits.id}}..1.0_f{{bits.id}}
           {% end %}
-        end
-
-        it "raises Alea::NaNError if max is NaN" do
-          expect_raises(Alea::NaNError) do
-            SpecRng.float max: 0.0 / 0.0
-          end
-        end
-
-        it "raises Alea::InfinityError if max is Infinity" do
-          expect_raises(Alea::InfinityError) do
-            SpecRng.float max: 1.0 / 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if max is 0" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.float max: 0.0
-          end
-        end
-
-        it "raises Alea::UndefinedError if max is negative" do
-          expect_raises(Alea::UndefinedError) do
-            SpecRng.float max: -1.0
-          end
         end
 
         it "raises Alea::NaNError if left bound is NaN" do
@@ -210,74 +182,41 @@ describe Alea do
           SpecRng.float(0.0..0.0).should eq(0.0)
         end
 
-        it "returns uniformly-distributed random values with fixed limit" do
-          ary = Array(Float64).new
-          ans = 0.0
+        # mean  is:   (b + a) / 2
+        # stdev is:   (b - a) / sqrt( 12 )
 
-          SpecNdata.times do
-            ran = SpecRng.float 9377.0
-            ans += ran
-            ary << ran
-          end
+        dist_test("generates uniform-distributed random values with fixed max 9377.0 parameter",
+          caller: SpecRng,
+          method: :float,
+          params: {max: 9377.0},
+          sample_type: Float64,
+          real_mean: 4688.5,
+          real_stdev: 2706.9067370955604,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          # mean  is:   a / 2
-          # stdev is:   a / sqrt( 12 )
+        dist_test("generates uniform-distributed random values with fixed range 10...93 parameter",
+          caller: SpecRng,
+          method: :float,
+          params: {range: 10.0...93.0},
+          sample_type: Float64,
+          real_mean: 51.5,
+          real_stdev: 23.96003617136947,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
 
-          mean_r = 4688.5
-          stdev_r = 2706.9067370955604
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "returns uniformly-distributed random values with fixed range inclusive" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.float -10_000.0..93.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   (b + a) / 2
-          # stdev is:   (b - a) / sqrt( 12 )
-
-          mean_r = -4953.0
-          stdev_r = 2913.8868086000416
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
-
-        it "returns uniformly-distributed random values with fixed range exclusive" do
-          ary = Array(Float64).new
-          ans = 0.0
-
-          SpecNdata.times do
-            ran = SpecRng.float 10.0...93.0
-            ans += ran
-            ary << ran
-          end
-
-          # mean  is:   (b + a) / 2
-          # stdev is:   (b - a) / sqrt( 12 )
-
-          mean_r = 51.5
-          stdev_r = 23.96003617136947
-          tol = 0.005
-
-          mean = ans / SpecNdata
-          stdev = stdev(ary, mean, SpecNdata)
-          mean.should be_close(mean_r, tol * stdev_r)
-          stdev.should be_close(stdev_r, tol * stdev_r)
-        end
+        dist_test("generates uniform-distributed random values with fixed range -10_000..93 parameter",
+          caller: SpecRng,
+          method: :float,
+          params: {range: -10_000.0..93.0},
+          sample_type: Float64,
+          real_mean: -4953.0,
+          real_stdev: 2913.8868086000416,
+          mean_tol: 0.005,
+          stdev_tol: 0.005,
+        )
       end
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,3 +12,170 @@ def stdev(ary, mean, n)
   end
   Math.sqrt(ans / (n - 1))
 end
+
+# Compile-time expansion for generating parameterized specs over arguments passed to methods.
+#
+# **@parameters**:
+# * `{{message}}`: message to display in spec messages.
+# * `{{focus}}`: whether this spec is focused or not.
+# * `{{pending}}`: whether this spec is pending or not.
+# * `{{method}}`: the method this spec will address to.
+# * `{{params}}`: NamedTuple of the (initialized) parameter(s) to be passed to `{{method}}`.
+# * `{{types}}`: Array of types to be passed and checked.
+# * `{{return_type}}`: the type this method should return when `{{types}}` are passed.
+# * `{{caller}}`: the Object that will call `{{method}}`.
+macro arg_test(message, *, focus = false, pending = false, method,
+               params = nil, types, return_type, caller)
+  {% begin %}
+    {% if pending %}
+      pending {{message}}, focus: {{focus}} do
+    {% else %}
+      it {{message}}, focus: {{focus}} do
+    {% end %}
+      {% for type in types %}
+        # Update arguments passed with newly typed `1`s
+        %args = {
+          {% for key in params %}
+            {{key.id}}: {{type}}.new(1),
+          {% end %}
+        }
+        {{caller}}.{{method.id}}( **%args ).should be_a( {{return_type}} )
+      {% end %}
+      end
+  {% end %}
+end
+
+# Compile-time expansion for generating sanity (NaN/Infinity) checks specs over arguments.
+#
+# **@parameters**:
+# * `{{message}}`: message to display in spec messages.
+# * `{{focus}}`: whether this/these spec(s) is/are focused or not.
+# * `{{pending}}`: whether this/these spec(s) is/are pending or not.
+# * `{{method}}`: the method this/these spec(s) will address to.
+# * `{{params}}`: NamedTuple of the (initialized) parameter(s) to be passed to `{{method}}`.
+# * `{{params_to_check}}`: Array of the parameter(s) to be sanity-checked.
+# * `{{caller}}`: the Object that will call `{{method}}`.
+macro sanity_test(*, focus = false, pending = false, method, params, params_to_check, caller)
+  {% for param in params_to_check %}
+    {% if pending %}
+      pending "raises Alea::NaNError if {{param.id}} is NaN", focus: {{focus}} do
+    {% else %}
+      it "raises Alea::NaNError if {{param.id}} is NaN", focus: {{focus}} do
+    {% end %}
+        expect_raises(Alea::NaNError) do
+          # Update parameter to check with NaN
+          %args = {{params}}.merge({ {{param.id}}: 0.0 / 0.0 })
+          # Passing default values merged with parameter to check set as NaN
+          {{caller}}.{{method.id}}( **%args )
+        end
+      end
+
+    {% if pending %}
+      pending "raises Alea::InfinityError if {{param.id}} is Infinity", focus: {{focus}} do
+    {% else %}
+      it "raises Alea::InfinityError if {{param.id}} is Infinity", focus: {{focus}} do
+    {% end %}
+        expect_raises(Alea::InfinityError) do
+          # Update parameter to check with Infinity
+          %args = {{params}}.merge({ {{param.id}}: 1.0 / 0.0 })
+          # Passing default values merged with parameter to check set as Infinity
+          {{caller}}.{{method.id}}( **%args )
+        end
+      end
+  {% end %}
+end
+
+# Compile-time expansion for generating parameterized specs over arguments passed to methods.
+#
+# **@parameters**:
+# * `{{focus}}`: whether this spec(s) is/are focused or not.
+# * `{{pending}}`: whether this spec(s) is/are pending or not.
+# * `{{method}}`: the method this spec(s) will address to.
+# * `{{params}}`: NamedTuple of the (initialized) parameter(s) to be passed to `{{method}}`.
+# * `{{params_to_check}}`: Array of the parameter(s) to be sanity-checked.
+# * `{{check_negatives}}`: whether this spec(s) will check for negative-valued arguments or not.
+# * `{{check_zeros}}`: whether this spec(s) will check for zero-valued arguments or not.
+# * `{{caller}}`: the Object that will call `{{method}}`.
+macro param_test(*, focus = false, pending = false, method, params,
+                 params_to_check, check_negatives, check_zeros, caller)
+  {% for param in params_to_check %}
+    {% if check_negatives %}
+      {% if pending %}
+        pending "raises Alea::UndefinedError if {{param.id}} is negative", focus: {{focus}} do
+      {% else %}
+        it "raises Alea::UndefinedError if {{param.id}} is negative", focus: {{focus}} do
+      {% end %}
+          expect_raises(Alea::UndefinedError) do
+            # Update parameter to check with -1
+            %type = typeof( {{params}}[{{param}}] )
+            %args = {{params}}.merge({ {{param.id}}: %type.new(-1) })
+            # Passing default values merged with parameter to check set as -1
+            {{caller}}.{{method.id}}( **%args )
+          end
+        end
+    {% end %}
+
+    {% if check_zeros %}
+      {% if pending %}
+        pending "raises Alea::UndefinedError if {{param.id}} is zero", focus: {{focus}} do
+      {% else %}
+        it "raises Alea::UndefinedError if {{param.id}} is zero", focus: {{focus}} do
+      {% end %}
+          expect_raises(Alea::UndefinedError) do
+            # Update parameter to check with 0
+            %type = typeof( {{params}}[{{param}}] )
+            %args = {{params}}.merge({ {{param.id}}: %type.new(0) })
+            # Passing default values merged with parameter to check set as 0
+            {{caller}}.{{method.id}}( **%args )
+          end
+        end
+    {% end %}
+  {% end %}
+end
+
+# Compile-time expansion for generating parameterized specs over values returned from sampling methods.
+#
+# **@parameters**:
+# * `{{message}}`: message to display in spec messages.
+# * `{{focus}}`: whether this spec is focused or not.
+# * `{{pending}}`: whether this spec is pending or not.
+# * `{{method}}`: the method this spec will address to.
+# * `{{params}}`: NamedTuple of the (initialized) parameter(s) to be passed to `{{method}}`.
+# * `{{caller}}`: the Object that will call `{{method}}`.
+# * `{{samples}}`: number of samples to draw for mean and standard deviation.
+# * `{{sample_type}}`: return type of `{{method}}`.
+# * `{{real_mean}}`: expected value of mean from the distribution.
+# * `{{real_stdev}}`: expected value of standard deviation from the distribution.
+# * `{{mean_tol}}`: percent err. (of stdev) within calculated mean is expected to pass.
+# * `{{stdev_tol}}`: percent err. (of stdev) within calculated stdev is expected to pass.
+macro dist_test(message, *,
+                focus = false, pending = false, method, params = nil,
+                caller, samples = SpecNdata, sample_type,
+                real_mean, real_stdev, mean_tol, stdev_tol)
+  {% begin %}
+    {% if pending %}
+      pending {{message}}, focus: {{focus}} do
+    {% else %}
+      it {{message}}, focus: {{focus}} do
+    {% end %}
+        ary = Array({{sample_type}}).new {{samples}}
+        ans = {{sample_type}}.new 0
+
+        {{samples}}.times do
+          {% if params %}
+            ran = {{caller}}.{{method.id}}( **{{params}} )
+          {% else %}
+            ran = {{caller}}.{{method.id}}
+          {% end %}
+          ans += ran / {{samples}}
+          ary << ran
+        end
+
+        mean = ans
+        stdev = stdev(ary, mean, {{samples}})
+
+        mean.should be_close({{real_mean}}, {{mean_tol}} * {{real_stdev}})
+        stdev.should be_close({{real_stdev}}, {{stdev_tol}} * {{real_stdev}})
+      end
+  {% end %}
+end

--- a/src/alea/internal/ipoiss.cr
+++ b/src/alea/internal/ipoiss.cr
@@ -18,7 +18,7 @@ module Alea::Internal
       ((us >= 0.07) && (v <= vr)) && return k
       ((k < 0) || ((us < 0.013) && (v > us))) && next
       log = Math.log(v) + Math.log(inv) - Math.log(a / (us * us) + b)
-      gam = -lam + k * llam - Math.lgamma(k + 1i64)
+      gam = -(lam - k * llam + Math.lgamma(k + 1i64))
       (log <= gam) && return k
     end
   end
@@ -26,6 +26,7 @@ module Alea::Internal
   # Ok here to pass the prng: it's a reference and
   # it will not affect repeatability.
   def self.poisson_mult(lam : Float | Int, prng : Alea::PRNG)
+    lam = lam.to_f
     enlam = Math.exp(-lam)
     x = 0i64
     prod = 1.0

--- a/src/alea/prob/pchisq.cr
+++ b/src/alea/prob/pchisq.cr
@@ -10,7 +10,7 @@ module Alea::CDF
   # * `Alea::NaNError` if any of the arguments is `NaN`.
   # * `Alea::InfinityError` if any of the arguments is `Infinity`.
   # * `Alea::UndefinedError` if `df` is negative or zero.
-  def self.chisq(x : Float, df : Float = 1.0) : Float64
+  def self.chisq(x : Float, df : Float) : Float64
     Alea.sanity_check(x, :x, :chisq)
     Alea.sanity_check(df, :df, :chisq)
     Alea.param_check(df, :<=, 0.0, :df, :chisq)


### PR DESCRIPTION
This PR reshapes the format for basic (and redundant) specs.
Macros was added to perform compile-time expansion for generating: 
- `arg_test` for checks over argument types passed to methods
- `sanity_test` for sanity check specs over `Float64` arguments
- `param_test` for parameter check specs
- `dist_test` for parametric distribution specs